### PR TITLE
Fix additional read of the `queueManager` field

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/nas/NativeAudioSendFactory.java
+++ b/LavalinkServer/src/main/java/lavalink/server/nas/NativeAudioSendFactory.java
@@ -91,11 +91,11 @@ public class NativeAudioSendFactory implements IAudioSendFactory {
     }
 
     private void populateQueues() {
-        UdpQueueManager manager = queueManager;
+        UdpQueueManager manager = queueManager; /* avoid getfield opcode */
 
         if (manager != null) {
             for (NativeAudioSendSystem system : systems) {
-                system.populateQueue(queueManager);
+                system.populateQueue(manager);
             }
         }
     }


### PR DESCRIPTION
It's not fixed [upstream](https://github.com/sedmelluq/jda-nas/pull/2/files#diff-1aabec908196a583920e3bb501b0266bR76) but maybe you do think it's good to have this fix.