### PR TITLE
Add /decodetrack endpoint to REST api

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -22,7 +22,6 @@
 
 package lavalink.server.player;
 
-import com.sedmelluq.discord.lavaplayer.tools.io.MessageInput;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import lavalink.server.Launcher;
@@ -38,7 +37,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -22,7 +22,9 @@
 
 package lavalink.server.player;
 
+import com.sedmelluq.discord.lavaplayer.tools.io.MessageInput;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import lavalink.server.Launcher;
 import lavalink.server.util.Util;
 import org.json.JSONArray;
@@ -36,6 +38,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -44,19 +47,29 @@ public class AudioLoaderRestHandler {
 
     private static final Logger log = LoggerFactory.getLogger(AudioLoaderRestHandler.class);
 
-    @GetMapping(value = "/loadtracks", produces = "application/json")
-    @ResponseBody
-    public String get(HttpServletRequest request, HttpServletResponse response, @RequestParam String identifier)
-            throws IOException, InterruptedException {
+    private void log(HttpServletRequest request) {
         String path = request.getServletPath();
         log.info("GET " + path);
+    }
 
+    private boolean isAuthorized(HttpServletRequest request, HttpServletResponse response) {
         if (request.getHeader("Authorization") != null &&
                 !request.getHeader("Authorization").equals(Launcher.config.getPassword())) {
             log.warn("Authorization failed");
             response.setStatus(403);
-            return "";
+            return false;
         }
+        return true;
+    }
+
+    @GetMapping(value = "/loadtracks", produces = "application/json")
+    @ResponseBody
+    public String getLoadTracks(HttpServletRequest request, HttpServletResponse response, @RequestParam String identifier)
+            throws IOException, InterruptedException {
+        log(request);
+
+        if (!isAuthorized(request, response))
+            return "";
 
         JSONObject json = new JSONObject();
         JSONArray tracks = new JSONArray();
@@ -72,6 +85,29 @@ public class AudioLoaderRestHandler {
 
         json.put("tracks", tracks);
         return json.toString();
+    }
+
+    @GetMapping(value = "/decodetrack", produces = "application/json")
+    @ResponseBody
+    public String getDecodeTrack(HttpServletRequest request, HttpServletResponse response, @RequestParam String track) throws IOException {
+        log(request);
+
+        if (!isAuthorized(request, response))
+            return "";
+
+        AudioTrack audioTrack = Util.toAudioTrack(track);
+        AudioTrackInfo trackInfo = audioTrack.getInfo();
+
+        return new JSONObject()
+                .put("title", trackInfo.title)
+                .put("author", trackInfo.author)
+                .put("length", track.length())
+                .put("identifier", trackInfo.identifier)
+                .put("uri", trackInfo.uri)
+                .put("isStream", trackInfo.isStream)
+                .put("isSeekable", audioTrack.isSeekable())
+                .put("position", audioTrack.getPosition())
+                .toString();
     }
 
 }


### PR DESCRIPTION
This endpoint allows lavaplayer encoded tracks to be decoded to view the AudioTrack info. Non java clients cannot do this without implementing lavaplayer's DefaultAudioPlayerManager track decoding & each source manager's track decoder which is a lengthy process and would require updating whenever a new source manager is added or changed.

Example request:
```
GET /decodetrack?track=QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==
```
```json
{
    "identifier": "dQw4w9WgXcQ",
    "isSeekable": true,
    "author": "RickAstleyVEVO",
    "length": 196,
    "isStream": false,
    "position": 0,
    "title": "Rick Astley - Never Gonna Give You Up",
    "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
}
```