### PR TITLE
Proper websocket close & server shutdown handling

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.java
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.java
@@ -63,6 +63,15 @@ public class Launcher {
         if (config.getSentryDsn() != null && !config.getSentryDsn().isEmpty()) {
             Sentry.init(config.getSentryDsn());
         }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Shutdown hook triggered");
+            try {
+                socketServer.stop(30);
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while stopping socket server", e);
+            }
+        }, "shutdown hook"));
     }
 
     public static void main(String[] args) {

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.java
@@ -25,6 +25,7 @@ package lavalink.server.io;
 import lavalink.server.player.Player;
 import lavalink.server.util.Util;
 import net.dv8tion.jda.Core;
+import net.dv8tion.jda.manager.AudioManager;
 import org.java_websocket.WebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +103,12 @@ public class SocketContext {
         playerUpdateService.shutdown();
         players.keySet().forEach(s -> {
             Core core = cores.get(Util.getShardFromSnowflake(s, shardCount));
-            core.getAudioManager(s).closeAudioConnection();
+            if (core != null) {
+                AudioManager audioManager = core.getAudioManager(s);
+                if (audioManager != null) {
+                    audioManager.closeAudioConnection();
+                }
+            }
         });
 
         players.values().forEach(Player::stop);

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
@@ -73,10 +73,28 @@ public class SocketServer extends WebSocketServer {
     }
 
     @Override
-    public void onClose(WebSocket webSocket, int i, String s, boolean b) {
-        log.info("Connection closed from " + webSocket.getRemoteSocketAddress().toString() + " with protocol " + webSocket.getDraft());
-        contextMap.get(webSocket).shutdown();
-        contextMap.remove(webSocket);
+    public void onCloseInitiated(WebSocket webSocket, int code, String reason) {
+        close(webSocket, code, reason);
+    }
+
+    @Override
+    public void onClosing(WebSocket webSocket, int code, String reason, boolean remote) {
+        close(webSocket, code, reason);
+    }
+
+    @Override
+    public void onClose(WebSocket webSocket, int code, String reason, boolean remote) {
+        close(webSocket, code, reason);
+    }
+
+    // WebSocketServer has a very questionable attitude towards communicating close events, so we override ALL the closing methods
+    private void close(WebSocket webSocket, int code, String reason) {
+        SocketContext context = contextMap.remove(webSocket);
+        if (context != null) {
+            log.info("Connection closed from {} with protocol {} with reason {} with code {}",
+                    webSocket.getRemoteSocketAddress().toString(), webSocket.getDraft(), reason, code);
+            context.shutdown();
+        }
     }
 
     @Override


### PR DESCRIPTION
Catch all doz websocket closing events and act on them (possibly preventing a leak of SocketContexts)
Add a shutdown hook