### PR TITLE
Allow setting of a custom buffer

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -14,3 +14,4 @@ lavalink:
       http: true
       local: false
     sentryDsn: ""
+    bufferDurationMs:

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -14,4 +14,4 @@ lavalink:
       http: true
       local: false
     sentryDsn: ""
-    bufferDurationMs:
+    bufferDurationMs: 400

--- a/LavalinkServer/src/main/java/lavalink/server/Config.java
+++ b/LavalinkServer/src/main/java/lavalink/server/Config.java
@@ -25,6 +25,8 @@ package lavalink.server;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
+
 @ConfigurationProperties(prefix = "lavalink.server")
 @Component
 public class Config {
@@ -53,6 +55,18 @@ public class Config {
 
     public void setSentryDsn(String sentryDsn) {
         this.sentryDsn = sentryDsn;
+    }
+
+    @Nullable
+    public Integer bufferDurationMs;
+
+    @Nullable
+    public Integer getBufferDurationMs() {
+        return bufferDurationMs;
+    }
+
+    public void setBufferDurationMs(@Nullable Integer bufferDurationMs) {
+        this.bufferDurationMs = bufferDurationMs;
     }
 
     public static class Sources {

--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.java
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.java
@@ -120,7 +120,17 @@ public class Launcher {
                 && !System.getProperty("os.arch").equalsIgnoreCase("arm")
                 && !System.getProperty("os.arch").equalsIgnoreCase("arm-linux")
                 ) {
-            AudioConnection.setAudioSendFactory(new NativeAudioSendFactory());
+
+            Integer customBuffer = config.getBufferDurationMs();
+            NativeAudioSendFactory nativeAudioSendFactory;
+            if (customBuffer != null) {
+                log.info("Setting buffer to {}ms", customBuffer);
+                nativeAudioSendFactory = new NativeAudioSendFactory(customBuffer);
+            } else {
+                log.info("Using default buffer");
+                nativeAudioSendFactory = new NativeAudioSendFactory();
+            }
+            AudioConnection.setAudioSendFactory(nativeAudioSendFactory);
             log.info("JDA-NAS supported system detected. Enabled native audio sending.");
         } else {
             log.warn("This system and architecture appears to not support native audio sending! "


### PR DESCRIPTION
Idk how to handle Spring properties properly but this doesn't throw any exceptions when anything is missing in the config.

This is an "experimental" feature based on this PR https://github.com/sedmelluq/jda-nas/pull/5 which I pulled into our jda-nas fork already. We talked about wanting this months ago, but never actually implemented it, so here it is.