### PR TITLE
Added Feedback for Failed Resolved Tracks

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -204,6 +204,8 @@ Server emitted an event. See the client implementation below.
  * 1. TrackEndEvent
  * 2. TrackExceptionEvent
  * 3. TrackStuckEvent
+ * 4. TrackStartEvent
+ * 5. TrackResolveErrorEvent
  * <p>
  * The remaining are caused by the client
  */

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -230,6 +230,12 @@ private void handleEvent(JSONObject json) throws IOException {
                     json.getLong("thresholdMs")
             );
             break;
+        case "TrackStartEvent":
+            event = new TrackStartEvent(player,  LavalinkUtil.toAudioTrack(json.getString("track")));
+            break;
+        case "TrackResolveErrorEvent":
+            event = new TrackResolveErrorEvent(player, player.getPlayingTrack());
+            break;
         default:
             log.warn("Unexpected event type: " + json.getString("type"));
             break;

--- a/LavalinkClient/src/main/java/lavalink/client/io/LavalinkSocket.java
+++ b/LavalinkClient/src/main/java/lavalink/client/io/LavalinkSocket.java
@@ -28,6 +28,8 @@ import lavalink.client.player.LavalinkPlayer;
 import lavalink.client.player.event.PlayerEvent;
 import lavalink.client.player.event.TrackEndEvent;
 import lavalink.client.player.event.TrackExceptionEvent;
+import lavalink.client.player.event.TrackResolveErrorEvent;
+import lavalink.client.player.event.TrackStartEvent;
 import lavalink.client.player.event.TrackStuckEvent;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
@@ -187,6 +189,12 @@ public class LavalinkSocket extends ReusableWebSocket {
                         LavalinkUtil.toAudioTrack(json.getString("track")),
                         json.getLong("thresholdMs")
                 );
+                break;
+            case "TrackStartEvent":
+                event = new TrackStartEvent(player,  LavalinkUtil.toAudioTrack(json.getString("track")));
+                break;
+            case "TrackResolveErrorEvent":
+                event = new TrackResolveErrorEvent(player, player.getPlayingTrack());
                 break;
             default:
                 log.warn("Unexpected event type: " + json.getString("type"));

--- a/LavalinkClient/src/main/java/lavalink/client/player/LavalinkInternalPlayerEventHandler.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/LavalinkInternalPlayerEventHandler.java
@@ -27,7 +27,17 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 import lavalink.client.player.event.PlayerEventListenerAdapter;
 
 class LavalinkInternalPlayerEventHandler extends PlayerEventListenerAdapter {
-
+    @Override
+    public void onTrackStart(IPlayer player, AudioTrack track) {
+         ((LavalinkPlayer) player).track = track;
+         ((LavalinkPlayer) player).loadingTrack = false;
+    }
+    
+    @Override
+    public void onTrackResolveError(IPlayer player, AudioTrack track) {
+         ((LavalinkPlayer) player).loadingTrack = false;
+    }
+    
     @Override
     public void onTrackEnd(IPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         ((LavalinkPlayer) player).clearTrack();

--- a/LavalinkClient/src/main/java/lavalink/client/player/LavaplayerPlayerWrapper.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/LavaplayerPlayerWrapper.java
@@ -99,4 +99,9 @@ public class LavaplayerPlayerWrapper implements IPlayer {
         return player.provide();
     }
 
+    @Override
+    public boolean isLoadingSong() {
+        return false;
+    }
+
 }

--- a/LavalinkClient/src/main/java/lavalink/client/player/event/PlayerEventListenerAdapter.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/event/PlayerEventListenerAdapter.java
@@ -77,6 +77,14 @@ public class PlayerEventListenerAdapter implements IPlayerEventListener {
         // Adapter dummy method
     }
 
+    
+    /**
+     * @param player Audio player
+     * @param track Audio track where the exception occurred
+     */
+    public void onTrackResolveError(IPlayer player, AudioTrack track) {
+        // Adapter dummy method
+    }
 
     @Override
     public void onEvent(PlayerEvent event) {

--- a/LavalinkClient/src/main/java/lavalink/client/player/event/TrackResolveErrorEvent.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/event/TrackResolveErrorEvent.java
@@ -20,35 +20,23 @@
  * SOFTWARE.
  */
 
-package lavalink.client.player;
+package lavalink.client.player.event;
 
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
-import lavalink.client.player.event.IPlayerEventListener;
 
-public interface IPlayer {
+import lavalink.client.player.IPlayer;
 
-    AudioTrack getPlayingTrack();
+public class TrackResolveErrorEvent extends PlayerEvent {
 
-    void playTrack(AudioTrack track);
+	private AudioTrack track;
 
-    void stopTrack();
+	public TrackResolveErrorEvent(IPlayer player, AudioTrack track) {
+		super(player);
+		this.track = track;
+	}
 
-    void setPaused(boolean b);
-
-    boolean isPaused();
-
-    long getTrackPosition();
-
-    void seekTo(long position);
-
-    void setVolume(int volume);
-
-    int getVolume();
-
-    void addListener(IPlayerEventListener listener);
-
-    void removeListener(IPlayerEventListener listener);
-
-    boolean isLoadingSong();
+	public AudioTrack getTrack() {
+		return track;
+	}
 
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
@@ -45,6 +45,21 @@ public class EventEmitter extends AudioEventAdapter {
     }
 
     @Override
+    public void onTrackStart(AudioPlayer player, AudioTrack track) {
+        JSONObject out = new JSONObject();
+        out.put("op", "event");
+        out.put("type", "TrackStartEvent");
+        out.put("guildId", linkPlayer.getGuildId());
+        try {
+            out.put("track", Util.toMessage(track));
+        } catch (@SuppressWarnings("unused") IOException e) {
+            out.put("track", JSONObject.NULL);
+        }
+
+        linkPlayer.getSocket().getSocket().send(out.toString());
+    }
+
+    @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         JSONObject out = new JSONObject();
         out.put("op", "event");
@@ -52,7 +67,7 @@ public class EventEmitter extends AudioEventAdapter {
         out.put("guildId", linkPlayer.getGuildId());
         try {
             out.put("track", Util.toMessage(track));
-        } catch (IOException e) {
+        } catch (@SuppressWarnings("unused") IOException e) {
             out.put("track", JSONObject.NULL);
         }
 


### PR DESCRIPTION
- Added new event TrackResolveErrorEvent as feedback incase tracks get resolved incorrectly by LavaLink
- TrackStartEvent is now sent from the Node when the song starts playing instead of just sending it when you want to play a track