### PR TITLE
Fix getPlayingTrack null bug

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -34,6 +34,7 @@ Provide an intercepted voice server update
 ```json
 {
     "op": "voiceUpdate",
+    "guildId": "...",
     "sessionId": "...",
     "event": "..."
 }

--- a/LavalinkClient/src/main/java/lavalink/client/player/LavalinkInternalPlayerEventHandler.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/LavalinkInternalPlayerEventHandler.java
@@ -30,6 +30,7 @@ class LavalinkInternalPlayerEventHandler extends PlayerEventListenerAdapter {
 
     @Override
     public void onTrackEnd(IPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
+        if (endReason == AudioTrackEndReason.REPLACED || endReason == AudioTrackEndReason.STOPPED) return;
         ((LavalinkPlayer) player).clearTrack();
     }
 }


### PR DESCRIPTION
This should fix the bug where if a track is replaced (end reason REPLACED) it becomes null, also fixes a possible race condition by ignoring STOPPED.