### PR TITLE
Fix getPlayingTrack null bug

### DIFF
--- a/LavalinkClient/src/main/java/lavalink/client/player/LavalinkInternalPlayerEventHandler.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/LavalinkInternalPlayerEventHandler.java
@@ -30,6 +30,8 @@ class LavalinkInternalPlayerEventHandler extends PlayerEventListenerAdapter {
 
     @Override
     public void onTrackEnd(IPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
-        ((LavalinkPlayer) player).clearTrack();
+        if (endReason != AudioTrackEndReason.REPLACED && endReason != AudioTrackEndReason.STOPPED) {
+            ((LavalinkPlayer) player).clearTrack();
+        }
     }
 }


### PR DESCRIPTION
This should fix the bug where if a track is replaced (end reason REPLACED) it becomes null, also fixes a possible race condition by ignoring STOPPED.