### PR TITLE
add lavalink.js to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Being used in production by FredBoat and Dyno.
 * [JDA client](https://github.com/Frederikam/Lavalink/tree/master/LavalinkClient) (JDA, Java)
 * [eris-lavalink](https://github.com/briantanner/eris-lavalink) (Eris, JavaScript)
 * [lava-d.js](https://github.com/untocodes/lava-d.js) (discord.js, JavaScript)
-* [discord.js-lavalink](https://github.com/MrJacz/discord.js-lavalink) (discord.js, JavaScript)
+* [lavalink.js](https://github.com/briantanner/lavalink.js) (discord.js, JavaScript)
 * Or [create your own](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md)
 
 ## Server configuration


### PR DESCRIPTION
Update the link to the discord.js port of eris-lavalink