### PR TITLE
Fix already-created youtube source manager instance not being used

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.java
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.java
@@ -132,6 +132,13 @@ public class Launcher {
             } else {
                 log.info("Using default buffer");
             }
+
+            Integer customPlaylistLimit = config.getYoutubePlaylistLoadLimit();
+            if (customPlaylistLimit != null) {
+                log.info("Setting playlist load limit to {}", customPlaylistLimit);
+            } else {
+                log.info("Using default playlist load limit");
+            }
         } else {
             log.warn("This system and architecture appears to not support native audio sending! "
                     + "GC pauses may cause your bot to stutter during playback.");

--- a/LavalinkServer/src/main/java/lavalink/server/player/Player.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/Player.java
@@ -65,7 +65,7 @@ public class Player extends AudioEventAdapter implements AudioSendHandler {
             Integer playlistLoadLimit = Launcher.config.getYoutubePlaylistLoadLimit();
 
             if (playlistLoadLimit != null) youtube.setPlaylistPageCount(playlistLoadLimit);
-            PLAYER_MANAGER.registerSourceManager(new YoutubeAudioSourceManager());
+            PLAYER_MANAGER.registerSourceManager(youtube);
         }
         if (sources.isBandcamp()) PLAYER_MANAGER.registerSourceManager(new BandcampAudioSourceManager());
         if (sources.isSoundcloud()) PLAYER_MANAGER.registerSourceManager(new SoundCloudAudioSourceManager());


### PR DESCRIPTION
This fixes my stupidity (where I forget to use the already-created youtube audio source manager) and adds logging for the playlist load limit.


I'm kinda surprised I didn't pick up on it originally, my bad.
