### PR TITLE
Add Discord.js-lavalink to the list of Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Being used in production by FredBoat, Dyno, Rythm, LewdBot, and more.
 * [pylava](https://github.com/Pandentia/pylava) (discord.py, Python)
 * [SandySounds](https://github.com/MrJohnCoder/SandySounds) (JavaScript)
 * [eris-lavalink](https://github.com/briantanner/eris-lavalink) (Eris, JavaScript)
+* [discord.js-lavalink](https://github.com/MrJacz/discord.js-lavalink/) (Discord.js, JavaScript)
 * Or [create your own](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md)
 
 ### Supports 1.x:


### PR DESCRIPTION
Add Discord.js-lavalink to the list of Client libraries that support v2