### PR TITLE
Update lavaplayer

### DIFF
--- a/LavalinkClient/build.gradle
+++ b/LavalinkClient/build.gradle
@@ -4,7 +4,7 @@ ext {
     moduleName = 'Lavalink-Client'
 }
 dependencies {
-    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.2.51'
+    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.2.54'
     compile group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.3.7'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     compile group: 'org.json', name: 'json', version: '20180130'

--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -17,7 +17,7 @@ jar {
 publishToMavenLocal.dependsOn 'bootRepackage'
 
 dependencies {
-    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.2.51'
+    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.2.54'
     compile group: 'com.github.DV8FromTheWorld', name: 'JDA-Audio', version: '91438c36d7107cf838c2f2eb147b08f989d929db'
     compile group: 'com.github.FredBoat', name: 'jda-nas', version: '1.0.6.1-JDA-Audio'
     compile group: 'com.github.shredder121', name: 'jda-async-packetprovider', version: '1.1'


### PR DESCRIPTION
1.2.54 includes retry support for Socket Timeouts and also fixes mobile soundcloud link handling.