### PR TITLE
Add isPlaylist to response JSON

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -225,21 +225,24 @@ Authorization: youshallnotpass
 
 Response:
 ```json
-[
-  {
-    "track": "QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==",
-    "info": {
-      "identifier": "dQw4w9WgXcQ",
-      "isSeekable": true,
-      "author": "RickAstleyVEVO",
-      "length": 212000,
-      "isStream": false,
-      "position": 0,
-      "title": "Rick Astley - Never Gonna Give You Up",
-      "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+{
+  "isPlaylist": false,
+  "tracks": [
+    {
+      "track": "QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==",
+      "info": {
+        "identifier": "dQw4w9WgXcQ",
+        "isSeekable": true,
+        "author": "RickAstleyVEVO",
+        "length": 212000,
+        "isStream": false,
+        "position": 0,
+        "title": "Rick Astley - Never Gonna Give You Up",
+        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+      }
     }
-  }
-]
+  ]
+}
 ```
 
 ### Special notes

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class AudioLoader implements AudioLoadResultHandler {
@@ -109,7 +110,7 @@ class LoadResult {
     public boolean isPlaylist;
 
     public LoadResult(List<AudioTrack> tracks, boolean isPlaylist) {
-        this.tracks = tracks;
+        this.tracks = Collections.unmodifiableList(tracks);
         this.isPlaylist = isPlaylist;
     }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -39,13 +39,14 @@ public class AudioLoader implements AudioLoadResultHandler {
     private final AudioPlayerManager audioPlayerManager;
 
     private List<AudioTrack> loadedItems;
+    private boolean isPlaylist = false;
     private boolean used = false;
 
     public AudioLoader(AudioPlayerManager audioPlayerManager) {
         this.audioPlayerManager = audioPlayerManager;
     }
 
-    List<AudioTrack> loadSync(String identifier) throws InterruptedException {
+    LoadResult loadSync(String identifier) throws InterruptedException {
         if(used)
             throw new IllegalStateException("This loader can only be used once per instance");
 
@@ -57,7 +58,7 @@ public class AudioLoader implements AudioLoadResultHandler {
             this.wait();
         }
 
-        return loadedItems;
+        return new LoadResult(loadedItems, isPlaylist);
     }
 
     @Override
@@ -72,6 +73,10 @@ public class AudioLoader implements AudioLoadResultHandler {
 
     @Override
     public void playlistLoaded(AudioPlaylist audioPlaylist) {
+        if (!audioPlaylist.isSearchResult()) {
+            isPlaylist = true;
+        }
+
         log.info("Loaded playlist " + audioPlaylist.getName());
         loadedItems = audioPlaylist.getTracks();
         synchronized (this) {
@@ -97,4 +102,14 @@ public class AudioLoader implements AudioLoadResultHandler {
         }
     }
 
+}
+
+class LoadResult {
+    public List<AudioTrack> tracks;
+    public boolean isPlaylist;
+
+    public LoadResult(List<AudioTrack> tracks, boolean isPlaylist) {
+        this.tracks = tracks;
+        this.isPlaylist = isPlaylist;
+    }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -41,6 +41,8 @@ public class AudioLoader implements AudioLoadResultHandler {
 
     private List<AudioTrack> loadedItems;
     private boolean isPlaylist = false;
+    private String playlistName = null;
+    private Integer selectedTrack = null;
     private boolean used = false;
 
     public AudioLoader(AudioPlayerManager audioPlayerManager) {
@@ -59,7 +61,7 @@ public class AudioLoader implements AudioLoadResultHandler {
             this.wait();
         }
 
-        return new LoadResult(loadedItems, isPlaylist);
+        return new LoadResult(loadedItems, isPlaylist, playlistName, selectedTrack);
     }
 
     @Override
@@ -76,6 +78,8 @@ public class AudioLoader implements AudioLoadResultHandler {
     public void playlistLoaded(AudioPlaylist audioPlaylist) {
         if (!audioPlaylist.isSearchResult()) {
             isPlaylist = true;
+            playlistName = audioPlaylist.getName();
+            selectedTrack = audioPlaylist.getTracks().indexOf(audioPlaylist.getSelectedTrack());
         }
 
         log.info("Loaded playlist " + audioPlaylist.getName());
@@ -108,9 +112,13 @@ public class AudioLoader implements AudioLoadResultHandler {
 class LoadResult {
     public List<AudioTrack> tracks;
     public boolean isPlaylist;
+    public String playlistName;
+    public Integer selectedTrack;
 
-    public LoadResult(List<AudioTrack> tracks, boolean isPlaylist) {
+    public LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, Integer selectedTrack) {
         this.tracks = Collections.unmodifiableList(tracks);
         this.isPlaylist = isPlaylist;
+        this.playlistName = playlistName;
+        this.selectedTrack = selectedTrack;
     }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -41,7 +41,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
 
 @Controller
 public class AudioLoaderRestHandler {
@@ -97,10 +96,11 @@ public class AudioLoaderRestHandler {
         if (!isAuthorized(request, response))
             return "";
 
+        JSONObject json = new JSONObject();
         JSONArray tracks = new JSONArray();
-        List<AudioTrack> list = new AudioLoader(audioPlayerManager).loadSync(identifier);
+        LoadResult result = new AudioLoader(audioPlayerManager).loadSync(identifier);
 
-        list.forEach(track -> {
+        result.tracks.forEach(track -> {
             JSONObject object = new JSONObject();
             object.put("info", trackToJSON(track));
 
@@ -113,7 +113,10 @@ public class AudioLoaderRestHandler {
             }
         });
 
-        return tracks.toString();
+        json.put("isPlaylist", result.isPlaylist);
+        json.put("tracks", tracks);
+
+        return json.toString();
     }
 
     @GetMapping(value = "/decodetrack", produces = "application/json")

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -97,6 +97,7 @@ public class AudioLoaderRestHandler {
             return "";
 
         JSONObject json = new JSONObject();
+        JSONObject playlist = new JSONObject();
         JSONArray tracks = new JSONArray();
         LoadResult result = new AudioLoader(audioPlayerManager).loadSync(identifier);
 
@@ -113,7 +114,11 @@ public class AudioLoaderRestHandler {
             }
         });
 
+        playlist.put("name", result.playlistName);
+        playlist.put("selectedTrack", result.selectedTrack);
+
         json.put("isPlaylist", result.isPlaylist);
+        json.put("playlistInfo", playlist);
         json.put("tracks", tracks);
 
         return json.toString();


### PR DESCRIPTION
This allows clients to identify Search or Playlist results and handle the response accordingly.

**This is a breaking change to clients as it modifies the JSON that is returned**

Partially fulfills #38 