### PR TITLE
Fix exception thrown due to websocket port being in use when restarting

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
@@ -64,6 +64,7 @@ public class SocketServer extends WebSocketServer {
     public SocketServer(WebsocketConfig websocketConfig, ServerConfig serverConfig, AudioPlayerManager audioPlayerManager,
                         AudioSendFactoryConfiguration audioSendFactoryConfiguration) {
         super(new InetSocketAddress(websocketConfig.getHost(), websocketConfig.getPort()));
+        this.setReuseAddr(true);
         this.serverConfig = serverConfig;
         this.audioPlayerManager = audioPlayerManager;
         this.audioSendFactoryConfiguration = audioSendFactoryConfiguration;


### PR DESCRIPTION
Reported by @brussell98:
![image](https://user-images.githubusercontent.com/6048348/38762754-d552e4da-3f8f-11e8-9564-8262632bdd43.png)


Reproduced by SIGKILLING a lavalink that had a client connected.

Could not reproduce in several tries after adding the that is attached to this PR.

Related SO: https://stackoverflow.com/questions/31864369/java-net-bindexception-address-already-in-use-jvm-bind