### PR TITLE
[v3] Add custom sentry tags

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -16,9 +16,14 @@ lavalink:
       mixer: true
       http: true
       local: false
-    sentryDsn: ""
     bufferDurationMs: 400
     youtubePlaylistLoadLimit: 600
+
+sentry:
+  dsn: ""
+#  tags:
+#    some_key: some_value
+#    another_key: another_value
 
 logging:
   file:

--- a/LavalinkServer/src/main/java/lavalink/server/config/SentryConfigProperties.java
+++ b/LavalinkServer/src/main/java/lavalink/server/config/SentryConfigProperties.java
@@ -1,0 +1,34 @@
+package lavalink.server.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by napster on 20.05.18.
+ */
+@Component
+@ConfigurationProperties(prefix = "sentry")
+public class SentryConfigProperties {
+
+    private String dsn = "";
+    private Map<String, String> tags = new HashMap<>();
+
+    public String getDsn() {
+        return dsn;
+    }
+
+    public void setDsn(String dsn) {
+        this.dsn = dsn;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+}

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.java
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.java
@@ -43,6 +43,10 @@ public class ServerConfig {
 
     private String sentryDsn = "";
 
+    /**
+     * @deprecated use {@link SentryConfigProperties} instead.
+     */
+    @Deprecated(since = "3")
     public String getSentryDsn() {
         return sentryDsn;
     }


### PR DESCRIPTION
By default sentry tags the server name. This PR allows to set optional additional custom tags for a lavalink server instance, which then can be sorted by in sentry. This PR is useful when running more than one LL instance on one machine for example, or otherwise group and sort through reports of various instances.

Moved the sentry configuration into its own configuration key / class to avoid cluttering the server configuration. The previous dsn location is deprecated, but still supported and will result in a friendly warning detailing the new location / configuration key, until it is removed in a version post v3.