### PR TITLE
[dev] Replace Guava/jsr305 with spotbugs nullability annotations

### DIFF
--- a/LavalinkClient/build.gradle
+++ b/LavalinkClient/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     compile group: 'org.json', name: 'json', version: jsonOrgVersion
     compile group: 'net.dv8tion', name: 'JDA', version: jdaVersion
+    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
     compileOnly group: 'io.prometheus', name: 'simpleclient', version: prometheusVersion
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitJupiterVersion
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitJupiterVersion

--- a/LavalinkClient/src/main/java/lavalink/client/io/Lavalink.java
+++ b/LavalinkClient/src/main/java/lavalink/client/io/Lavalink.java
@@ -22,6 +22,7 @@
 
 package lavalink.client.io;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import lavalink.client.LavalinkUtil;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Guild;
@@ -36,7 +37,6 @@ import org.java_websocket.drafts.Draft_6455;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.Collection;
 import java.util.HashMap;
@@ -90,7 +90,7 @@ public class Lavalink extends ListenerAdapter {
 
     private static final AtomicInteger nodeCounter = new AtomicInteger(0);
 
-    public void addNode(@Nonnull URI serverUri, @Nonnull String password) {
+    public void addNode(@NonNull URI serverUri, @NonNull String password) {
         addNode("Lavalink_Node_#" + nodeCounter.getAndIncrement(), serverUri, password);
     }
 
@@ -102,7 +102,7 @@ public class Lavalink extends ListenerAdapter {
      * @param password
      *         password of the node to be added
      */
-    public void addNode(@Nonnull String name, @Nonnull URI serverUri, @Nonnull String password) {
+    public void addNode(@NonNull String name, @NonNull URI serverUri, @NonNull String password) {
         HashMap<String, String> headers = new HashMap<>();
         headers.put("Authorization", password);
         headers.put("Num-Shards", Integer.toString(numShards));
@@ -120,19 +120,19 @@ public class Lavalink extends ListenerAdapter {
     }
 
     @SuppressWarnings("unused")
-    @Nonnull
+    @NonNull
     public LavalinkLoadBalancer getLoadBalancer() {
         return loadBalancer;
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public Link getLink(String guildId) {
         return links.computeIfAbsent(guildId, __ -> new Link(this, guildId));
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public Link getLink(Guild guild) {
         return getLink(guild.getId());
     }
@@ -143,25 +143,25 @@ public class Lavalink extends ListenerAdapter {
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public Collection<Link> getLinks() {
         return links.values();
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public List<LavalinkSocket> getNodes() {
         return nodes;
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public JDA getJda(int shardId) {
         return jdaProvider.apply(shardId);
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public JDA getJdaFromSnowflake(String snowflake) {
         return jdaProvider.apply(LavalinkUtil.getShardFromSnowflake(snowflake, numShards));
     }

--- a/LavalinkClient/src/main/java/lavalink/client/io/LavalinkLoadBalancer.java
+++ b/LavalinkClient/src/main/java/lavalink/client/io/LavalinkLoadBalancer.java
@@ -22,7 +22,8 @@
 
 package lavalink.client.io;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +39,7 @@ public class LavalinkLoadBalancer {
         this.lavalink = lavalink;
     }
 
-    @Nonnull
+    @NonNull
     public LavalinkSocket determineBestSocket(long guild) {
         LavalinkSocket leastPenalty = null;
         int record = Integer.MAX_VALUE;

--- a/LavalinkClient/src/main/java/lavalink/client/io/LavalinkSocket.java
+++ b/LavalinkClient/src/main/java/lavalink/client/io/LavalinkSocket.java
@@ -23,6 +23,8 @@
 package lavalink.client.io;
 
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import lavalink.client.LavalinkUtil;
 import lavalink.client.player.LavalinkPlayer;
 import lavalink.client.player.event.PlayerEvent;
@@ -35,8 +37,6 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
@@ -49,19 +49,19 @@ public class LavalinkSocket extends ReusableWebSocket {
     private static final Logger log = LoggerFactory.getLogger(LavalinkSocket.class);
 
     private static final int TIMEOUT_MS = 5000;
-    @Nonnull
+    @NonNull
     private final String name;
-    @Nonnull
+    @NonNull
     private final Lavalink lavalink;
     @Nullable
     private RemoteStats stats;
     long lastReconnectAttempt = 0;
     private int reconnectsAttempted = 0;
-    @Nonnull
+    @NonNull
     private final URI remoteUri;
     private boolean available = false;
 
-    LavalinkSocket(@Nonnull String name, @Nonnull Lavalink lavalink, @Nonnull URI serverUri, Draft protocolDraft, Map<String, String> headers) {
+    LavalinkSocket(@NonNull String name, @NonNull Lavalink lavalink, @NonNull URI serverUri, Draft protocolDraft, Map<String, String> headers) {
         super(serverUri, protocolDraft, headers, TIMEOUT_MS);
         this.name = name;
         this.lavalink = lavalink;
@@ -179,7 +179,7 @@ public class LavalinkSocket extends ReusableWebSocket {
         }
     }
 
-    @Nonnull
+    @NonNull
     @SuppressWarnings("unused")
     public URI getRemoteUri() {
         return remoteUri;
@@ -204,7 +204,7 @@ public class LavalinkSocket extends ReusableWebSocket {
         return available && isOpen() && !isClosing();
     }
 
-    @Nonnull
+    @NonNull
     public String getName() {
         return name;
     }

--- a/LavalinkClient/src/main/java/lavalink/client/io/Link.java
+++ b/LavalinkClient/src/main/java/lavalink/client/io/Link.java
@@ -22,6 +22,8 @@
 
 package lavalink.client.io;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import lavalink.client.player.LavalinkPlayer;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
@@ -37,8 +39,6 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Indicates which node we are linked to, what voice channel to use, and what player we are using
@@ -237,7 +237,7 @@ public class Link {
         return state;
     }
 
-    void setState(@Nonnull State state) {
+    void setState(@NonNull State state) {
         if (this.state == State.DESTROYED && state != State.DESTROYED)
             throw new IllegalStateException("Cannot change state to " + state + " when state is " + State.DESTROYED);
         if (this.state == State.DESTROYING && state != State.DESTROYED) {
@@ -248,7 +248,7 @@ public class Link {
     }
 
     @SuppressWarnings("WeakerAccess")
-    @Nonnull
+    @NonNull
     public JDA getJda() {
         return lavalink.getJdaFromSnowflake(String.valueOf(guild));
     }
@@ -260,7 +260,7 @@ public class Link {
     /**
      * Setter used by {@link VoiceStateUpdateInterceptor} to change the expected channel
      */
-    void setChannel(@Nonnull VoiceChannel channel) {
+    void setChannel(@NonNull VoiceChannel channel) {
         this.channel = channel.getId();
     }
 

--- a/LavalinkClient/src/main/java/lavalink/client/io/metrics/LavalinkCollector.java
+++ b/LavalinkClient/src/main/java/lavalink/client/io/metrics/LavalinkCollector.java
@@ -1,12 +1,12 @@
 package lavalink.client.io.metrics;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
 import lavalink.client.io.Lavalink;
 import lavalink.client.io.LavalinkSocket;
 import lavalink.client.io.RemoteStats;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -21,7 +21,7 @@ public class LavalinkCollector extends Collector {
 
     private final Lavalink lavalink;
 
-    public LavalinkCollector(@Nonnull Lavalink lavalinkInstance) {
+    public LavalinkCollector(@NonNull Lavalink lavalinkInstance) {
         this.lavalink = lavalinkInstance;
     }
 

--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     compile group: 'io.sentry', name: 'sentry-logback', version: sentryLogbackVersion
     compile group: 'com.github.oshi', name: 'oshi-core', version: oshiVersion
     compile group: 'org.json', name: 'json', version: jsonOrgVersion
-    compile group: 'com.google.guava', name: 'guava', version: guavaVersion
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion
+    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
 }
 
 //create a simple version file that we will be reading to create appropriate docker tags

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.java
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.java
@@ -22,10 +22,10 @@
 
 package lavalink.server.config;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nullable;
 
 @ConfigurationProperties(prefix = "lavalink.server")
 @Component

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
         sentryLogbackVersion            = '1.7.0'
         oshiVersion                     = '3.4.4'
         jsonOrgVersion                  = '20180130'
-        guavaVersion                    = '24.0-jre'
+        spotbugsAnnotationsVersion      = '3.1.3'
         prometheusVersion               = '0.3.0'
 
         junitJupiterVersion             = '5.1.0'


### PR DESCRIPTION
This PR removes the (rather big) Guava dependency. The only feature of that lib that we use are the jsr305 nullability annotations, which are a bad idea to use anyways due to the pollution of the `javax.annotations` namespace, and are bound to be removed from guava. These annotations have been replaced with spotbug's nullability annotations (which work exactly the same way).

See also:
https://github.com/google/guava/issues/2960
https://github.com/spotbugs/spotbugs/issues/130