### PR TITLE
Add Histogram for GC pauses

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -19,6 +19,7 @@ lavalink:
     sentryDsn: ""
     bufferDurationMs: 400
     youtubePlaylistLoadLimit: 600
+    gc-warnings: true
 
 metrics:
   prometheus:

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.java
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.java
@@ -23,7 +23,10 @@ public class AudioPlayerConfiguration {
     public AudioPlayerManager audioPlayerManager(AudioSourcesConfig sources, ServerConfig serverConfig) {
 
         AudioPlayerManager audioPlayerManager = new DefaultAudioPlayerManager();
-        audioPlayerManager.enableGcMonitoring();
+
+        if (serverConfig.isGcWarnings()) {
+            audioPlayerManager.enableGcMonitoring();
+        }
 
         if (sources.isYoutube()) {
             YoutubeAudioSourceManager youtube = new YoutubeAudioSourceManager();

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.java
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.java
@@ -32,6 +32,12 @@ import org.springframework.stereotype.Component;
 public class ServerConfig {
 
     private String password;
+    private String sentryDsn = "";
+    @Nullable
+    private Integer bufferDurationMs;
+    @Nullable
+    private Integer youtubePlaylistLoadLimit;
+    private boolean gcWarnings = true;
 
     public String getPassword() {
         return password;
@@ -41,8 +47,6 @@ public class ServerConfig {
         this.password = password;
     }
 
-    private String sentryDsn = "";
-
     public String getSentryDsn() {
         return sentryDsn;
     }
@@ -50,9 +54,6 @@ public class ServerConfig {
     public void setSentryDsn(String sentryDsn) {
         this.sentryDsn = sentryDsn;
     }
-
-    @Nullable
-    public Integer bufferDurationMs;
 
     @Nullable
     public Integer getBufferDurationMs() {
@@ -64,14 +65,19 @@ public class ServerConfig {
     }
 
     @Nullable
-    private Integer youtubePlaylistLoadLimit;
-
-    @Nullable
     public Integer getYoutubePlaylistLoadLimit() {
         return youtubePlaylistLoadLimit;
     }
 
     public void setYoutubePlaylistLoadLimit(@Nullable Integer youtubePlaylistLoadLimit) {
         this.youtubePlaylistLoadLimit = youtubePlaylistLoadLimit;
+    }
+
+    public boolean isGcWarnings() {
+        return gcWarnings;
+    }
+
+    public void setGcWarnings(boolean gcWarnings) {
+        this.gcWarnings = gcWarnings;
     }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/GcNotificationListener.java
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/GcNotificationListener.java
@@ -1,0 +1,39 @@
+package lavalink.server.metrics;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Histogram;
+
+import javax.management.Notification;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+
+import static com.sun.management.GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION;
+import static com.sun.management.GarbageCollectionNotificationInfo.from;
+
+/**
+ * Created by napster on 21.05.18.
+ * <p>
+ * General idea taken from {@link com.sedmelluq.discord.lavaplayer.tools.GarbageCollectionMonitor}, thanks!
+ */
+public class GcNotificationListener implements NotificationListener {
+
+    private final Histogram gcPauses = Histogram.build()
+            .name("lavalink_gc_pauses_seconds")
+            .help("Garbage collection pauses by buckets")
+            .buckets(25, 50, 100, 200, 400, 800, 1600)
+            .register();
+
+    @Override
+    public void handleNotification(Notification notification, Object handback) {
+        if (GARBAGE_COLLECTION_NOTIFICATION.equals(notification.getType())) {
+            GarbageCollectionNotificationInfo notificationInfo = from((CompositeData) notification.getUserData());
+            GcInfo info = notificationInfo.getGcInfo();
+
+            if (info != null && !"No GC".equals(notificationInfo.getGcCause())) {
+                gcPauses.observe(info.getDuration() / Collector.MILLISECONDS_PER_SECOND);
+            }
+        }
+    }
+}

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/PrometheusMetrics.java
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/PrometheusMetrics.java
@@ -8,6 +8,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import javax.management.NotificationEmitter;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+
 /**
  * Created by napster on 08.05.18.
  */
@@ -29,6 +33,14 @@ public class PrometheusMetrics {
 
         //jvm (hotspot) metrics
         DefaultExports.initialize();
+
+        //gc pause buckets
+        final GcNotificationListener gcNotificationListener = new GcNotificationListener();
+        for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (gcBean instanceof NotificationEmitter) {
+                ((NotificationEmitter) gcBean).addNotificationListener(gcNotificationListener, null, gcBean);
+            }
+        }
 
         log.info("Prometheus metrics set up");
     }


### PR DESCRIPTION
Lavaplayers own warnings are not that accurate, we get many useless warnings in sentry:
![image](https://user-images.githubusercontent.com/6048348/40329693-a7f0f530-5d4a-11e8-9788-59a6fbae8233.png)

This PR makes these optional (default behaviour untouched), and instead offers a Histogram metric.