### PR TITLE
Update Lavaplayer to 1.2.64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
     ext {
         //@formatter:off
 
-        lavaplayerVersion               = '1.2.63'
+        lavaplayerVersion               = '1.2.64'
         jdaAudioVersion                 = '91438c36d7107cf838c2f2eb147b08f989d929db'
         jdaNasVersion                   = '1.0.6.2-JDA-Audio'
         jappVersion                     = '1.2'


### PR DESCRIPTION
This resolves an issue regarding WAV formats that have excess bytes