### PR TITLE
add lavaclient to list of libs which support v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Being used in production by FredBoat, Dyno, Rythm, LewdBot, and more.
 ## Client libraries:
 ### Supports 3.x and older:
 * [JDA client](https://github.com/Frederikam/Lavalink/tree/master/LavalinkClient) (JDA or generic, Java)
+* [LavaClient](https://github.com/SamOphis/LavaClient/tree/lavalink-v3) (Java)
 * [Lavalink.py](https://github.com/Devoxin/Lavalink.py) (discord.py, Python)
 * [SandySounds](https://github.com/MrJohnCoder/SandySounds) (JavaScript)
 


### PR DESCRIPTION
Added [LavaClient](https://github.com/SamOphis/LavaClient) to the list of libraries that support Lavalink Server v3.

An important thing to note is that I intentionally set the URL to the `lavalink-v3` branch of my repo since that branch (v1.0) **only** supports Lavalink Server v3, however the default `master` branch (v0.3) has a minor bug and only supports Lavalink Server v2. I chose to do this since v3 is not the default, officially-ready version of Lavalink, so making my library **only** support v3 would ruin it for now.

The link that I updated the README file with points to the `lavalink-v3` branch, but let me know if I should just point it to the default branch. Also, once v3 becomes default I'll merge the branches and submit a new pull request with the updated URL that points to the `master` branch.

Small little edit: The [official release of LavaClient v1.0](https://github.com/SamOphis/LavaClient/releases/tag/v1.0) does point this out more with bold sentences right at the very top, etc. It has some more information there that I omitted here for conciseness.