### PR TITLE
just updated lavaclient url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Being used in production by FredBoat, Dyno, Rythm, LewdBot, and more.
 ## Client libraries:
 ### Supports 3.x and older:
 * [JDA client](https://github.com/Frederikam/Lavalink/tree/master/LavalinkClient) (JDA or generic, Java)
+* [LavaClient](https://github.com/SamOphis/LavaClient) (Java)
 * [Lavalink.py](https://github.com/Devoxin/Lavalink.py) (discord.py, Python)
 * [SandySounds](https://github.com/MrJohnCoder/SandySounds) (JavaScript)
 


### PR DESCRIPTION
re-pointed URL at the actual github page and not a branch since latest version is compatible with v2 and v3, so no need to point at a branch.

last commit (merge remote-tracking thingy) is just me being super stupid at git so you can ignore it