### PR TITLE
Update Lavaplayer to 1.3.5

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -95,7 +95,7 @@ Make the player seek to a position of the track. Position is in millis
 }
 ```
 
-Set player volume. Volume may range from 0 to 150. 100 is default.
+Set player volume. Volume may range from 0 to 1000. 100 is default.
 ```json
 {
     "op": "volume",

--- a/LavalinkClient/src/main/java/lavalink/client/player/LavalinkPlayer.java
+++ b/LavalinkClient/src/main/java/lavalink/client/player/LavalinkPlayer.java
@@ -171,7 +171,7 @@ public class LavalinkPlayer implements IPlayer {
 
     @Override
     public void setVolume(int volume) {
-        volume = Math.min(150, Math.max(0, volume)); // Lavaplayer bounds
+        volume = Math.min(1000, Math.max(0, volume)); // Lavaplayer bounds
         this.volume = volume;
 
         LavalinkSocket node = link.getNode(false);

--- a/LavalinkServer/src/main/java/lavalink/server/player/Player.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/Player.java
@@ -111,7 +111,7 @@ public class Player extends AudioEventAdapter implements AudioSendHandler {
 
     @Override
     public byte[] provide20MsAudio() {
-        return lastFrame.data;
+        return lastFrame.getData();
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     ext {
         //@formatter:off
 
-        lavaplayerVersion               = '1.2.64'
+        lavaplayerVersion               = '1.3.5'
         jdaAudioVersion                 = '4d7abb48aec49f0a996ba0d87df34fdc67f71275'
         jdaNasVersion                   = '1.0.6.2-JDA-Audio'
         jappVersion                     = '1.2'


### PR DESCRIPTION
- Fixes issues regarding "AAC with SBR not properly supported in MP4 containers"
- Increases upper volume limit to 1000 (from 150, as per a change in Lavaplayer)