### PR TITLE
Load Types

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -232,7 +232,6 @@ Authorization: youshallnotpass
 Response:
 ```json
 {
-  "isPlaylist": false,
   "loadType": "TRACK_LOADED",
   "playlistInfo": {},
   "tracks": [
@@ -256,7 +255,6 @@ Response:
 If the identifier leads to a playlist, `playlistInfo` will contain two properties, `name` and `selectedTrack`
 ```json
 {
-  "isPlaylist": true,
   "loadType": "PLAYLIST_LOADED",
   "playlistInfo": {
     "name": "Example YouTube Playlist",

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -13,7 +13,7 @@ The Java client has support for JDA, but can also be adapted to work with other 
     * Hixie 75
 
 ## Significant changes v2.0 -> v3.0 
-* The response of `/loadtracks` has been completely changed (again!)
+* The response of `/loadtracks` has been completely changed (again since the initial v3.0 pre-release).
 * Lavalink v3.0 now reports its version as a handshake response header.
 `Lavalink-Major-Version` has a value of `3` for v3.0 only. It's missing for any older version.
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -13,7 +13,7 @@ The Java client has support for JDA, but can also be adapted to work with other 
     * Hixie 75
 
 ## Significant changes v2.0 -> v3.0 
-* The response of `/loadtracks` has been completely changed.
+* The response of `/loadtracks` has been completely changed (again!)
 * Lavalink v3.0 now reports its version as a handshake response header.
 `Lavalink-Major-Version` has a value of `3` for v3.0 only. It's missing for any older version.
 
@@ -233,6 +233,7 @@ Response:
 ```json
 {
   "isPlaylist": false,
+  "loadType": "TRACK_LOADED",
   "playlistInfo": {},
   "tracks": [
     {
@@ -256,6 +257,7 @@ If the identifier leads to a playlist, `playlistInfo` will contain two propertie
 ```json
 {
   "isPlaylist": true,
+  "loadType": "PLAYLIST_LOADED",
   "playlistInfo": {
     "name": "Example YouTube Playlist",
     "selectedTrack": 3
@@ -265,6 +267,13 @@ If the identifier leads to a playlist, `playlistInfo` will contain two propertie
   ]
 }
 ```
+
+Additionally, in every `/loadtracks` response, a `loadType` property is returned which can be used to judge the response from Lavalink properly. It can be one of the following:
+* `TRACK_LOADED` - Returned when a single track is loaded.
+* `PLAYLIST_LOADED` - Returned when a playlist is loaded.
+* `SEARCH_RESULT` - Returned when a search result is made (i.e `ytsearch: some song`).
+* `NO_MATCHES` - Returned if no matches/sources could be found for a given identifier.
+* `LOAD_FAILED` - Returned if Lavaplayer failed to load something for some reason.
 
 ### Special notes
 * When your shard's mainWS connection dies, so does all your lavalink audio connections.

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -39,7 +39,6 @@ public class AudioLoader implements AudioLoadResultHandler {
     private final AudioPlayerManager audioPlayerManager;
 
     private List<AudioTrack> loadedItems;
-    private boolean isPlaylist = false;
     private String playlistName = null;
     private Integer selectedTrack = null;
     private ResultStatus status = ResultStatus.UNKNOWN;
@@ -63,7 +62,7 @@ public class AudioLoader implements AudioLoadResultHandler {
 
         if (status == ResultStatus.UNKNOWN)
             throw new IllegalStateException("Load Type == UNKNOWN (shouldn't happen!)");
-        return new LoadResult(loadedItems, isPlaylist, playlistName, status, selectedTrack);
+        return new LoadResult(loadedItems, playlistName, status, selectedTrack);
     }
 
     @Override
@@ -80,7 +79,6 @@ public class AudioLoader implements AudioLoadResultHandler {
     @Override
     public void playlistLoaded(AudioPlaylist audioPlaylist) {
         if (!audioPlaylist.isSearchResult()) {
-            isPlaylist = true;
             playlistName = audioPlaylist.getName();
             selectedTrack = audioPlaylist.getTracks().indexOf(audioPlaylist.getSelectedTrack());
         }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -84,7 +84,7 @@ public class AudioLoader implements AudioLoadResultHandler {
         }
 
         log.info("Loaded playlist " + audioPlaylist.getName());
-        status = ResultStatus.PLAYLIST_LOADED;
+        status = audioPlaylist.isSearchResult() ? ResultStatus.SEARCH_RESULT : ResultStatus.PLAYLIST_LOADED;
         loadedItems = audioPlaylist.getTracks();
         synchronized (this) {
             this.notify();

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class AudioLoader implements AudioLoadResultHandler {
@@ -43,6 +42,7 @@ public class AudioLoader implements AudioLoadResultHandler {
     private boolean isPlaylist = false;
     private String playlistName = null;
     private Integer selectedTrack = null;
+    private ResultStatus status = ResultStatus.UNKNOWN;
     private boolean used = false;
 
     public AudioLoader(AudioPlayerManager audioPlayerManager) {
@@ -61,13 +61,14 @@ public class AudioLoader implements AudioLoadResultHandler {
             this.wait();
         }
 
-        return new LoadResult(loadedItems, isPlaylist, playlistName, selectedTrack);
+        return new LoadResult(loadedItems, isPlaylist, playlistName, status, selectedTrack);
     }
 
     @Override
     public void trackLoaded(AudioTrack audioTrack) {
         loadedItems = new ArrayList<>();
         loadedItems.add(audioTrack);
+        status = ResultStatus.TRACK_LOADED;
         log.info("Loaded track " + audioTrack.getInfo().title);
         synchronized (this) {
             this.notify();
@@ -83,6 +84,7 @@ public class AudioLoader implements AudioLoadResultHandler {
         }
 
         log.info("Loaded playlist " + audioPlaylist.getName());
+        status = ResultStatus.PLAYLIST_LOADED;
         loadedItems = audioPlaylist.getTracks();
         synchronized (this) {
             this.notify();
@@ -92,6 +94,7 @@ public class AudioLoader implements AudioLoadResultHandler {
     @Override
     public void noMatches() {
         log.info("No matches found");
+        status = ResultStatus.NO_MATCHES;
         loadedItems = new ArrayList<>();
         synchronized (this) {
             this.notify();
@@ -101,24 +104,11 @@ public class AudioLoader implements AudioLoadResultHandler {
     @Override
     public void loadFailed(FriendlyException e) {
         log.error("Load failed", e);
+        status = ResultStatus.LOAD_FAILED;
         loadedItems = new ArrayList<>();
         synchronized (this) {
             this.notify();
         }
     }
 
-}
-
-class LoadResult {
-    public List<AudioTrack> tracks;
-    public boolean isPlaylist;
-    public String playlistName;
-    public Integer selectedTrack;
-
-    public LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, Integer selectedTrack) {
-        this.tracks = Collections.unmodifiableList(tracks);
-        this.isPlaylist = isPlaylist;
-        this.playlistName = playlistName;
-        this.selectedTrack = selectedTrack;
-    }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -61,6 +61,8 @@ public class AudioLoader implements AudioLoadResultHandler {
             this.wait();
         }
 
+        if (status == ResultStatus.UNKNOWN)
+            throw new IllegalStateException("Load Type == UNKNOWN (shouldn't happen!)");
         return new LoadResult(loadedItems, isPlaylist, playlistName, status, selectedTrack);
     }
 

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -119,6 +119,7 @@ public class AudioLoaderRestHandler {
 
         json.put("isPlaylist", result.isPlaylist);
         json.put("playlistInfo", playlist);
+        json.put("loadType", result.loadResultType);
         json.put("tracks", tracks);
 
         return json.toString();

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -117,7 +117,6 @@ public class AudioLoaderRestHandler {
         playlist.put("name", result.playlistName);
         playlist.put("selectedTrack", result.selectedTrack);
 
-        json.put("isPlaylist", result.isPlaylist);
         json.put("playlistInfo", playlist);
         json.put("loadType", result.loadResultType);
         json.put("tracks", tracks);

--- a/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
@@ -9,14 +9,14 @@ class LoadResult {
     public List<AudioTrack> tracks;
     public boolean isPlaylist;
     public String playlistName;
-    public String loadResultType;
+    public ResultStatus loadResultType;
     public Integer selectedTrack;
 
     LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, ResultStatus loadResultType, Integer selectedTrack) {
         this.tracks = Collections.unmodifiableList(tracks);
         this.isPlaylist = isPlaylist;
         this.playlistName = playlistName;
-        this.loadResultType = loadResultType.name();
+        this.loadResultType = loadResultType;
         this.selectedTrack = selectedTrack;
     }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
@@ -7,14 +7,12 @@ import java.util.List;
 
 class LoadResult {
     public List<AudioTrack> tracks;
-    public boolean isPlaylist;
     public String playlistName;
     public ResultStatus loadResultType;
     public Integer selectedTrack;
 
-    LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, ResultStatus loadResultType, Integer selectedTrack) {
+    LoadResult(List<AudioTrack> tracks, String playlistName, ResultStatus loadResultType, Integer selectedTrack) {
         this.tracks = Collections.unmodifiableList(tracks);
-        this.isPlaylist = isPlaylist;
         this.playlistName = playlistName;
         this.loadResultType = loadResultType;
         this.selectedTrack = selectedTrack;

--- a/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
@@ -1,0 +1,22 @@
+package lavalink.server.player;
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+
+import java.util.Collections;
+import java.util.List;
+
+class LoadResult {
+    public List<AudioTrack> tracks;
+    public boolean isPlaylist;
+    public String playlistName;
+    public String loadResultType;
+    public Integer selectedTrack;
+
+    LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, ResultStatus loadResultType, Integer selectedTrack) {
+        this.tracks = Collections.unmodifiableList(tracks);
+        this.isPlaylist = isPlaylist;
+        this.playlistName = playlistName;
+        this.loadResultType = loadResultType.name();
+        this.selectedTrack = selectedTrack;
+    }
+}

--- a/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
@@ -1,0 +1,9 @@
+package lavalink.server.player;
+
+public enum ResultStatus {
+    TRACK_LOADED,
+    PLAYLIST_LOADED,
+    NO_MATCHES,
+    LOAD_FAILED,
+    UNKNOWN
+}

--- a/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
@@ -3,6 +3,7 @@ package lavalink.server.player;
 public enum ResultStatus {
     TRACK_LOADED,
     PLAYLIST_LOADED,
+    SEARCH_RESULT,
     NO_MATCHES,
     LOAD_FAILED,
     UNKNOWN

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Being used in production by FredBoat, Dyno, Rythm, LewdBot, and more.
 * Basic authentication
 
 ## Changes in 3.0
-* Breaking changes to the output of the /loadtracks endpoint https://github.com/Frederikam/Lavalink/pull/91
+* Breaking changes to the output of the /loadtracks endpoint. [See PR #91](https://github.com/Frederikam/Lavalink/pull/91) [and PR #116](https://github.com/Frederikam/Lavalink/pull/116).
 * The Java client has been made generic. This is a breaking change so please read the documentation.
 
 ## Client libraries:


### PR DESCRIPTION
Allows clients to determine if a call to the /loadtracks endpoint resulted in: a successful track load, a playlist/search load, no matches found or a load failure. Previously Lavalink simply returned an empty array of tracks for the last two cases. This PR doesn't change any of that: it still behaves exactly like it did before but with an added `loadType` field that is equal to either `TRACK_LOADED`, `PLAYLIST_LOADED`, `SEARCH_RESULT`, `NO_MATCHES` or `LOAD_FAILED`.


![image](https://i.imgur.com/4JGhEWo.png)

Proof that this PR works with search results. ^
Additionally, with the latest commit it might be feasible to remove the `isPlaylist` field and have it be replaced with the `loadType` one, however this would be a breaking change for clients like my own which expect strictly-formatted responses, or those which already have support for that feature.
