### PR TITLE
StatsTask Cancellation Fix

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
@@ -227,6 +227,8 @@ public class SocketServer extends WebSocketServer {
     }
 
     public static void sendPlayerUpdate(WebSocket webSocket, Player player) {
+        if (webSocket.isClosed())
+            return;
         JSONObject json = new JSONObject();
         json.put("op", "playerUpdate");
         json.put("guildId", player.getGuildId());

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
@@ -125,10 +125,11 @@ public class SocketServer extends WebSocketServer {
     private void close(WebSocket webSocket, int code, String reason) {
         SocketContext context = contextMap.remove(webSocket);
         if (context != null) {
-            context.getStatsFuture().cancel(true);
             log.info("Connection closed from {} with protocol {} with reason {} with code {}",
                     webSocket.getRemoteSocketAddress().toString(), webSocket.getDraft(), reason, code);
             context.shutdown();
+            if (!context.getStatsFuture().isCancelled())
+                context.getStatsFuture().cancel(true);
         }
     }
 

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.java
@@ -125,6 +125,7 @@ public class SocketServer extends WebSocketServer {
     private void close(WebSocket webSocket, int code, String reason) {
         SocketContext context = contextMap.remove(webSocket);
         if (context != null) {
+            context.getStatsFuture().cancel(true);
             log.info("Connection closed from {} with protocol {} with reason {} with code {}",
                     webSocket.getRemoteSocketAddress().toString(), webSocket.getDraft(), reason, code);
             context.shutdown();

--- a/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java
@@ -116,7 +116,8 @@ public class StatsTask implements Runnable {
             out.put("frameStats", frames);
         }
 
-        context.getSocket().send(out.toString());
+        if (context.getSocket().isOpen())
+            context.getSocket().send(out.toString());
     }
 
     private double uptime = 0;

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -84,7 +84,7 @@ public class AudioLoader implements AudioLoadResultHandler {
         }
 
         log.info("Loaded playlist " + audioPlaylist.getName());
-        status = ResultStatus.PLAYLIST_LOADED;
+        status = audioPlaylist.isSearchResult() ? ResultStatus.SEARCH_RESULT : ResultStatus.PLAYLIST_LOADED;
         loadedItems = audioPlaylist.getTracks();
         synchronized (this) {
             this.notify();

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoader.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class AudioLoader implements AudioLoadResultHandler {
@@ -43,6 +42,7 @@ public class AudioLoader implements AudioLoadResultHandler {
     private boolean isPlaylist = false;
     private String playlistName = null;
     private Integer selectedTrack = null;
+    private ResultStatus status = ResultStatus.UNKNOWN;
     private boolean used = false;
 
     public AudioLoader(AudioPlayerManager audioPlayerManager) {
@@ -61,13 +61,14 @@ public class AudioLoader implements AudioLoadResultHandler {
             this.wait();
         }
 
-        return new LoadResult(loadedItems, isPlaylist, playlistName, selectedTrack);
+        return new LoadResult(loadedItems, isPlaylist, playlistName, status, selectedTrack);
     }
 
     @Override
     public void trackLoaded(AudioTrack audioTrack) {
         loadedItems = new ArrayList<>();
         loadedItems.add(audioTrack);
+        status = ResultStatus.TRACK_LOADED;
         log.info("Loaded track " + audioTrack.getInfo().title);
         synchronized (this) {
             this.notify();
@@ -83,6 +84,7 @@ public class AudioLoader implements AudioLoadResultHandler {
         }
 
         log.info("Loaded playlist " + audioPlaylist.getName());
+        status = ResultStatus.PLAYLIST_LOADED;
         loadedItems = audioPlaylist.getTracks();
         synchronized (this) {
             this.notify();
@@ -92,6 +94,7 @@ public class AudioLoader implements AudioLoadResultHandler {
     @Override
     public void noMatches() {
         log.info("No matches found");
+        status = ResultStatus.NO_MATCHES;
         loadedItems = new ArrayList<>();
         synchronized (this) {
             this.notify();
@@ -101,24 +104,11 @@ public class AudioLoader implements AudioLoadResultHandler {
     @Override
     public void loadFailed(FriendlyException e) {
         log.error("Load failed", e);
+        status = ResultStatus.LOAD_FAILED;
         loadedItems = new ArrayList<>();
         synchronized (this) {
             this.notify();
         }
     }
 
-}
-
-class LoadResult {
-    public List<AudioTrack> tracks;
-    public boolean isPlaylist;
-    public String playlistName;
-    public Integer selectedTrack;
-
-    public LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, Integer selectedTrack) {
-        this.tracks = Collections.unmodifiableList(tracks);
-        this.isPlaylist = isPlaylist;
-        this.playlistName = playlistName;
-        this.selectedTrack = selectedTrack;
-    }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -119,6 +119,7 @@ public class AudioLoaderRestHandler {
 
         json.put("isPlaylist", result.isPlaylist);
         json.put("playlistInfo", playlist);
+        json.put("loadType", result.loadResultType);
         json.put("tracks", tracks);
 
         return json.toString();

--- a/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/LoadResult.java
@@ -1,0 +1,22 @@
+package lavalink.server.player;
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+
+import java.util.Collections;
+import java.util.List;
+
+class LoadResult {
+    public List<AudioTrack> tracks;
+    public boolean isPlaylist;
+    public String playlistName;
+    public String loadResultType;
+    public Integer selectedTrack;
+
+    LoadResult(List<AudioTrack> tracks, boolean isPlaylist, String playlistName, ResultStatus loadResultType, Integer selectedTrack) {
+        this.tracks = Collections.unmodifiableList(tracks);
+        this.isPlaylist = isPlaylist;
+        this.playlistName = playlistName;
+        this.loadResultType = loadResultType.name();
+        this.selectedTrack = selectedTrack;
+    }
+}

--- a/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
@@ -1,0 +1,9 @@
+package lavalink.server.player;
+
+public enum ResultStatus {
+    TRACK_LOADED,
+    PLAYLIST_LOADED,
+    NO_MATCHES,
+    LOAD_FAILED,
+    UNKNOWN
+}

--- a/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/ResultStatus.java
@@ -3,6 +3,7 @@ package lavalink.server.player;
 public enum ResultStatus {
     TRACK_LOADED,
     PLAYLIST_LOADED,
+    SEARCH_RESULT,
     NO_MATCHES,
     LOAD_FAILED,
     UNKNOWN


### PR DESCRIPTION
Fixes a bug when a Lavalink connection is improperly shut-down, so it continues to try to send stats updates.

This builds on top of the commits from #116 due to me being stupid and not basing this branch on a new fork. Feel free to close both this and/or #116 if need be (compatibility, one being merged but not the other, etc.).