### PR TITLE
Infer version from git tag

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -3,10 +3,11 @@ import org.apache.tools.ant.filters.ReplaceTokens
 apply plugin: 'application'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.gorylenko.gradle-git-properties'
+apply plugin: 'org.ajoberstar.grgit'
 
 description = 'Play audio to discord voice channels'
 mainClassName = "lavalink.server.Launcher"
-version '3.0'
+version = "${versionFromTag()}".toString()
 ext {
     moduleName = 'Lavalink-Server'
 }
@@ -64,6 +65,28 @@ processResources {
                 "env.BUILD_NUMBER"  : (System.getenv('CI') ? System.getenv('BUILD_NUMBER') : 'DEV'),
                 "env.BUILD_TIME"    : System.currentTimeMillis() + ''
         ]
+    }
+}
+
+build {
+    doLast {
+        println 'Version: ' + version
+    }
+}
+
+@SuppressWarnings("GrMethodMayBeStatic")
+String versionFromTag() {
+
+    def headTag = grgit.tag.list().find {
+        it.commit == grgit.head()
+    }
+
+    def clean = grgit.status().clean //uncommitted changes? -> should be SNAPSHOT
+
+    if (headTag && clean) {
+        headTag.getName()
+    } else {
+        "${grgit.head().id}-SNAPSHOT"
     }
 }
 


### PR DESCRIPTION
Will produce the version for the lavalink server like this:
If there is a git tag, and the repository is in a clean state, the version will be exactly the git tag.
Otherwise it will be <githash>-SNAPSHOT.

This will require adjusting the docker release script on the CI server to expect the githash version flavor, but can be done at a later point in time. I'll assign that task to myself, to do it after the v3 is published.