### PR TITLE
No more "Channel is closed" when emitting events

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
@@ -62,7 +62,7 @@ public class EventEmitter extends AudioEventAdapter {
 
         out.put("reason", endReason.toString());
 
-        Ws.send(linkPlayer.getSocket().getSession(), out);
+        Ws.sendIfOpen(linkPlayer.getSocket().getSession(), out);
     }
 
     // These exceptions are already logged by Lavaplayer
@@ -80,7 +80,7 @@ public class EventEmitter extends AudioEventAdapter {
 
         out.put("error", exception.getMessage());
 
-        Ws.send(linkPlayer.getSocket().getSession(), out);
+        Ws.sendIfOpen(linkPlayer.getSocket().getSession(), out);
     }
 
     @Override
@@ -99,7 +99,7 @@ public class EventEmitter extends AudioEventAdapter {
 
         out.put("thresholdMs", thresholdMs);
 
-        Ws.send(linkPlayer.getSocket().getSession(), out);
+        Ws.sendIfOpen(linkPlayer.getSocket().getSession(), out);
         SocketServer.sendPlayerUpdate(linkPlayer.getSocket().getSession(), linkPlayer);
     }
 

--- a/LavalinkServer/src/main/java/lavalink/server/util/Ws.java
+++ b/LavalinkServer/src/main/java/lavalink/server/util/Ws.java
@@ -14,6 +14,13 @@ public class Ws {
 
     private static final Logger log = LoggerFactory.getLogger(Ws.class);
 
+    /**
+     * Like #send(), but without logging an exception if the socket is closed.
+     */
+    public static void sendIfOpen(WebSocketSession session, JSONObject json) {
+        if (session.isOpen()) send(session, json);
+    }
+
     public static void send(WebSocketSession session, JSONObject json) {
         UndertowSession undertowSession = (UndertowSession) ((StandardWebSocketSession) session).getNativeSession();
         WebSockets.sendText(json.toString(), undertowSession.getWebSocketChannel(),


### PR DESCRIPTION
Fixes #51, although as of #147 the exception is an IOException from Undertow.

The original exception was caused by two problems:
* Presumably bad closing behavior by the old WS server (fixed by #147 )
* Attempting to emit events for a closed/closing `SocketContext`

Testing is appreciated. 