### PR TITLE
Small adjustments to Equalizer stuff

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -123,7 +123,7 @@ Using the player equalizer
     ]
 }
 ```
-There are 16 bands (0-15) that can be changed.
+There are 15 bands (0-14) that can be changed.
 `gain` is the multiplier for the given band. The default value is 0. Valid values range from -0.25 to 1.0,
 where -0.25 means the given band is completely muted, and 0.25 means it is doubled. Modifying the gain could
 also change the volume of the output.

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.java
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.java
@@ -45,6 +45,8 @@ public class AudioPlayerConfiguration {
             if (sources.isHttp()) audioPlayerManager.registerSourceManager(new HttpAudioSourceManager());
             if (sources.isLocal()) audioPlayerManager.registerSourceManager(new LocalAudioSourceManager());
 
+            audioPlayerManager.getConfiguration().setFilterHotSwapEnabled(true);
+
             return audioPlayerManager;
         };
     }

--- a/LavalinkServer/src/main/java/lavalink/server/player/Player.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/Player.java
@@ -91,6 +91,7 @@ public class Player extends AudioEventAdapter implements AudioSendHandler {
     }
 
     public void setBandGain(int band, float gain) {
+        log.debug("Setting band {}'s gain to {}", band, gain);
         equalizerFactory.setGain(band, gain);
 
         if (gain == 0.0f) {
@@ -110,7 +111,7 @@ public class Player extends AudioEventAdapter implements AudioSendHandler {
                 this.player.setFilterFactory(null);
                 this.isEqualizerApplied = false;
             }
-        } else {
+        } else if (!this.isEqualizerApplied) {
             this.player.setFilterFactory(equalizerFactory);
             this.isEqualizerApplied = true;
         }


### PR DESCRIPTION
This PR aims to fix a few issues that users have informed me regarding equalizer factory. For some reason, equalizer changes weren't applied until the new track began playing.

I'm unable to reproduce this issue myself (working on Windows x64, and Linux x64 systems), so I asked the users to try "patched builds" that included `.setFilterHotSwapEnabled(true)`, and all reported back that the fix was working.

I also fixed a minor documentation issue regarding band counts. Not sure how I missed that but it's now fixed :)