### PR TITLE
Replace oshi with calls to native JVM apis

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     compile group: 'org.springframework', name: 'spring-websocket', version: springWebSocketVersion
     compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
     compile group: 'io.sentry', name: 'sentry-logback', version: sentryLogbackVersion
-    compile group: 'com.github.oshi', name: 'oshi-core', version: oshiVersion
     compile group: 'org.json', name: 'json', version: jsonOrgVersion
     compile(group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion) {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'

--- a/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java
@@ -23,24 +23,20 @@
 package lavalink.server.io;
 
 import lavalink.server.Launcher;
+import lavalink.server.metrics.CpuTimer;
 import lavalink.server.player.AudioLossCounter;
 import lavalink.server.player.Player;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import oshi.SystemInfo;
-import oshi.hardware.HardwareAbstractionLayer;
-import oshi.software.os.OSProcess;
-import oshi.software.os.OperatingSystem;
 
 public class StatsTask implements Runnable {
 
     private static final Logger log = LoggerFactory.getLogger(StatsTask.class);
 
+    private CpuTimer cpuTimer = new CpuTimer();
     private SocketContext context;
     private final SocketServer socketServer;
-
-    private final SystemInfo si = new SystemInfo();
 
     StatsTask(SocketContext context, SocketServer socketServer) {
         this.context = context;
@@ -82,16 +78,10 @@ public class StatsTask implements Runnable {
         mem.put("reservable", Runtime.getRuntime().maxMemory());
         out.put("memory", mem);
 
-        HardwareAbstractionLayer hal = si.getHardware();
-
-
-
         JSONObject cpu = new JSONObject();
         cpu.put("cores", Runtime.getRuntime().availableProcessors());
-        cpu.put("systemLoad", hal.getProcessor().getSystemCpuLoad());
-        double load = getProcessRecentCpuUsage();
-        if (!Double.isFinite(load)) load = 0;
-        cpu.put("lavalinkLoad", load);
+        cpu.put("systemLoad", this.cpuTimer.getSystemRecentCpuUsage());
+        cpu.put("lavalinkLoad", this.cpuTimer.getProcessRecentCpuUsage());
 
         out.put("cpu", cpu);
 
@@ -123,27 +113,5 @@ public class StatsTask implements Runnable {
         context.send(out);
     }
 
-    private double uptime = 0;
-    private double cpuTime = 0;
-
-    private double getProcessRecentCpuUsage() {
-        double output;
-        HardwareAbstractionLayer hal = si.getHardware();
-        OperatingSystem os = si.getOperatingSystem();
-        OSProcess p = os.getProcess(os.getProcessId());
-
-        if (cpuTime != 0) {
-            double uptimeDiff = p.getUpTime() - uptime;
-            double cpuDiff = (p.getKernelTime() + p.getUserTime()) - cpuTime;
-            output = cpuDiff / uptimeDiff;
-        } else {
-            output = ((double) (p.getKernelTime() + p.getUserTime())) / (double) p.getUserTime();
-        }
-
-        // Record for next invocation
-        uptime = p.getUpTime();
-        cpuTime = p.getKernelTime() + p.getUserTime();
-        return output / hal.getProcessor().getLogicalProcessorCount();
-    }
 
 }

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/CpuTimer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/CpuTimer.java
@@ -1,0 +1,92 @@
+package lavalink.server.metrics;
+
+import javax.annotation.Nullable;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Created by napster on 06.05.19.
+ */
+public class CpuTimer {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CpuTimer.class);
+
+    static final double ERROR = -1.0;
+
+    private final OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+
+    public double getProcessRecentCpuUsage() {
+        try {
+            //between 0.0 and 1.0, 1.0 meaning all CPU cores were running threads of this JVM
+            // see com.sun.management.OperatingSystemMXBean#getProcessCpuLoad and https://www.ibm.com/support/knowledgecenter/en/SSYKE2_7.1.0/com.ibm.java.api.71.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuLoad()
+            Double processCpuTime = callDoubleGetter("getProcessCpuLoad", this.osBean);
+
+            return processCpuTime != null ? processCpuTime : ERROR;
+        } catch (Exception e) {
+            log.debug("Could not access process cpu time", e);
+            return ERROR;
+        }
+    }
+
+    public double getSystemRecentCpuUsage() {
+        try {
+            //between 0.0 and 1.0, 1.0 meaning all CPU cores were busy
+            // see com.sun.management.OperatingSystemMXBean#getSystemCpuLoad and https://www.ibm.com/support/knowledgecenter/en/SSYKE2_7.1.0/com.ibm.java.api.71.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getSystemCpuLoad()
+            Double processCpuTime = callDoubleGetter("getSystemCpuLoad", this.osBean);
+
+            return processCpuTime != null ? processCpuTime : ERROR;
+        } catch (Exception e) {
+            log.debug("Could not access system cpu time", e);
+            return ERROR;
+        }
+    }
+
+    // Code below copied from Prometheus's StandardExports (Apache 2.0) with slight modifications
+
+    @Nullable
+    private static Double callDoubleGetter(String getterName, Object obj)
+            throws NoSuchMethodException, InvocationTargetException {
+        return callDoubleGetter(obj.getClass().getMethod(getterName), obj);
+    }
+
+    /**
+     * Attempts to call a method either directly or via one of the implemented interfaces.
+     * <p>
+     * A Method object refers to a specific method declared in a specific class. The first invocation
+     * might happen with method == SomeConcreteClass.publicLongGetter() and will fail if
+     * SomeConcreteClass is not public. We then recurse over all interfaces implemented by
+     * SomeConcreteClass (or extended by those interfaces and so on) until we eventually invoke
+     * callMethod() with method == SomePublicInterface.publicLongGetter(), which will then succeed.
+     * <p>
+     * There is a built-in assumption that the method will never return null (or, equivalently, that
+     * it returns the primitive data type, i.e. {@code long} rather than {@code Long}). If this
+     * assumption doesn't hold, the method might be called repeatedly and the returned value will be
+     * the one produced by the last call.
+     */
+    @Nullable
+    private static Double callDoubleGetter(Method method, Object obj) throws InvocationTargetException {
+        try {
+            return (Double) method.invoke(obj);
+        } catch (IllegalAccessException e) {
+            // Expected, the declaring class or interface might not be public.
+        }
+
+        // Iterate over all implemented/extended interfaces and attempt invoking the method with the
+        // same name and parameters on each.
+        for (Class<?> clazz : method.getDeclaringClass().getInterfaces()) {
+            try {
+                Method interfaceMethod = clazz.getMethod(method.getName(), method.getParameterTypes());
+                Double result = callDoubleGetter(interfaceMethod, obj);
+                if (result != null) {
+                    return result;
+                }
+            } catch (NoSuchMethodException e) {
+                // Expected, class might implement multiple, unrelated interfaces.
+            }
+        }
+
+        return null;
+    }
+}

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/CpuTimer.java
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/CpuTimer.java
@@ -21,9 +21,9 @@ public class CpuTimer {
         try {
             //between 0.0 and 1.0, 1.0 meaning all CPU cores were running threads of this JVM
             // see com.sun.management.OperatingSystemMXBean#getProcessCpuLoad and https://www.ibm.com/support/knowledgecenter/en/SSYKE2_7.1.0/com.ibm.java.api.71.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuLoad()
-            Double processCpuTime = callDoubleGetter("getProcessCpuLoad", this.osBean);
+            Double processCpuLoad = callDoubleGetter("getProcessCpuLoad", this.osBean);
 
-            return processCpuTime != null ? processCpuTime : ERROR;
+            return processCpuLoad != null ? processCpuLoad : ERROR;
         } catch (Exception e) {
             log.debug("Could not access process cpu time", e);
             return ERROR;
@@ -34,9 +34,9 @@ public class CpuTimer {
         try {
             //between 0.0 and 1.0, 1.0 meaning all CPU cores were busy
             // see com.sun.management.OperatingSystemMXBean#getSystemCpuLoad and https://www.ibm.com/support/knowledgecenter/en/SSYKE2_7.1.0/com.ibm.java.api.71.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getSystemCpuLoad()
-            Double processCpuTime = callDoubleGetter("getSystemCpuLoad", this.osBean);
+            Double systemCpuLoad = callDoubleGetter("getSystemCpuLoad", this.osBean);
 
-            return processCpuTime != null ? processCpuTime : ERROR;
+            return systemCpuLoad != null ? systemCpuLoad : ERROR;
         } catch (Exception e) {
             log.debug("Could not access system cpu time", e);
             return ERROR;

--- a/LavalinkServer/src/test/java/lavalink/server/metrics/CpuTimerTest.java
+++ b/LavalinkServer/src/test/java/lavalink/server/metrics/CpuTimerTest.java
@@ -1,0 +1,26 @@
+package lavalink.server.metrics;
+
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+
+/**
+ * Created by napster on 06.05.19.
+ */
+public class CpuTimerTest {
+
+    @Test
+    public void getProcessRecentCpuUsage() {
+        CpuTimer cpuTimer = new CpuTimer();
+        cpuTimer.getProcessRecentCpuUsage(); //first call may be negative
+        assertTrue(cpuTimer.getProcessRecentCpuUsage() > CpuTimer.ERROR);
+    }
+
+    @Test
+    public void getSystemRecentCpuUsage() {
+        CpuTimer cpuTimer = new CpuTimer();
+        cpuTimer.getSystemRecentCpuUsage(); //first call may be negative
+        assertTrue(cpuTimer.getSystemRecentCpuUsage() > CpuTimer.ERROR);
+    }
+}

--- a/LavalinkServer/src/test/java/lavalink/server/metrics/CpuTimerTest.java
+++ b/LavalinkServer/src/test/java/lavalink/server/metrics/CpuTimerTest.java
@@ -11,16 +11,22 @@ import static junit.framework.TestCase.assertTrue;
 public class CpuTimerTest {
 
     @Test
-    public void getProcessRecentCpuUsage() {
+    public void getProcessRecentCpuUsage() throws InterruptedException {
         CpuTimer cpuTimer = new CpuTimer();
-        cpuTimer.getProcessRecentCpuUsage(); //first call may be negative
+        if (cpuTimer.getProcessRecentCpuUsage() <= CpuTimer.ERROR) {
+            //first call may be negative and/or the specific JVM requires a bit more time to populate
+            Thread.sleep(1000);
+        }
         assertTrue(cpuTimer.getProcessRecentCpuUsage() > CpuTimer.ERROR);
     }
 
     @Test
-    public void getSystemRecentCpuUsage() {
+    public void getSystemRecentCpuUsage() throws InterruptedException {
         CpuTimer cpuTimer = new CpuTimer();
-        cpuTimer.getSystemRecentCpuUsage(); //first call may be negative
+        if (cpuTimer.getSystemRecentCpuUsage() <= CpuTimer.ERROR) {
+            //first call may be negative and/or the specific JVM requires a bit more time to populate
+            Thread.sleep(1000);
+        }
         assertTrue(cpuTimer.getSystemRecentCpuUsage() > CpuTimer.ERROR);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ subprojects {
         springWebSocketVersion          = '5.0.8.RELEASE'
         logbackVersion                  = '1.2.3'
         sentryLogbackVersion            = '1.7.7'
-        oshiVersion                     = '3.13.0'
         jsonOrgVersion                  = '20180813'
         spotbugsAnnotationsVersion      = '3.1.6'
         prometheusVersion               = '0.5.0'


### PR DESCRIPTION
Should solve the occasional bugs with oshi, as well as plain wrong and therefore useless CPU readings.

Probably only works on certain JVMs (OpenJDK, IBM/Eclipse J9), and probably not on Windows.

Fixes #158