### PR TITLE
Add Friendly exception to TrackExceptionEvent

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -12,7 +12,7 @@ The Java client has support for JDA, but can also be adapted to work with other 
     * Hixie 76
     * Hixie 75
 
-## Significant changes v3.0 -> v3.1
+## Significant changes v3.0 -> v4.0
 The `error` string on the `TrackExceptionEvent` has been deprecated and replaced by 
 the `exception` object following the same structure as the `LOAD_FAILED` error on [`/loadtracks`](#rest-api)
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -12,6 +12,10 @@ The Java client has support for JDA, but can also be adapted to work with other 
     * Hixie 76
     * Hixie 75
 
+## Significant changes v3.0 -> v3.1
+The `error` string on the `TrackExceptionEvent` has been deprecated and replaced by 
+the `exception` object following the same structure as the `LOAD_FAILED` error on [`/loadtracks`](#rest-api)
+
 ## Significant changes v2.0 -> v3.0 
 * The response of `/loadtracks` has been completely changed (again since the initial v3.0 pre-release).
 * Lavalink v3.0 now reports its version as a handshake response header.
@@ -225,7 +229,7 @@ private void handleEvent(JSONObject json) throws IOException {
                     new FriendlyException(
                         jsonEx.getString("message"),
                         FriendlyException.Severity.valueOf(jsonEx.getString("severity")),
-                        new Exception(jsonEx.getString("cause"))
+                        new RuntimeException(jsonEx.getString("cause"))
                     )
             );
             break;

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -219,9 +219,14 @@ private void handleEvent(JSONObject json) throws IOException {
             );
             break;
         case "TrackExceptionEvent":
+            JSONObject jsonEx = json.getJSONObject("exception");
             event = new TrackExceptionEvent(player,
                     LavalinkUtil.toAudioTrack(json.getString("track")),
-                    new RemoteTrackException(json.getString("error"))
+                    new FriendlyException(
+                        jsonEx.getString("message"),
+                        FriendlyException.Severity.valueOf(jsonEx.getString("severity")),
+                        new Exception(jsonEx.getString("cause"))
+                    )
             );
             break;
         case "TrackStuckEvent":

--- a/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
@@ -78,6 +78,11 @@ public class EventEmitter extends AudioEventAdapter {
         }
 
         out.put("error", exception.getMessage());
+        JSONObject exceptionJson = new JSONObject();
+        exceptionJson.put("message", exception.getMessage());
+        exceptionJson.put("severity", exception.severity.toString());
+        exceptionJson.put("cause", Util.getRootCause(exception).toString());
+        out.put("exception", exceptionJson);
 
         linkPlayer.getSocket().send(out);
     }

--- a/LavalinkServer/src/main/java/lavalink/server/util/Util.java
+++ b/LavalinkServer/src/main/java/lavalink/server/util/Util.java
@@ -50,4 +50,12 @@ public class Util {
         return Base64.encodeBase64String(baos.toByteArray());
     }
 
+    public static Throwable getRootCause(Throwable throwable) {
+        Throwable rootCause = throwable;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+        return rootCause;
+    }
+
 }


### PR DESCRIPTION
This PR adds the FriendlyException from lava player to the TrackExceptionEvent so the java client can make use of this and return the correct severity.

Example output: (tested with the lofi hip hop radio stream)
```json
{
  "exception": {
    "severity": "FAULT",
    "cause": "org.apache.http.ConnectionClosedException: Premature end of chunk coded message body: closing chunk expected",
    "message": "Something went wrong when decoding the track."
  },
  "op": "event",
  "type": "TrackExceptionEvent",
  "track": "QAAAkAIALGxvZmkgaGlwIGhvcCByYWRpbyAtIGJlYXRzIHRvIHJlbGF4L3N0dWR5IHRvAApDaGlsbGVkQ293f/////////8AC2hIVzFvWTI2a3hRAQEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9aEhXMW9ZMjZreFEAB3lvdXR1YmUAAAAAAAAX/A==",
  "error": "Something went wrong when decoding the track.",
  "guildId": "191245668617158656"
}
``` 

Closes #198