### PR TITLE
Update lavaplayer to version 1.3.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     ext {
         //@formatter:off
 
-        lavaplayerVersion               = '1.3.17'
+        lavaplayerVersion               = '1.3.18'
         magmaVersion                    = '0.9.0'
         jdaNasVersion                   = '1.0.6'
         jappVersion                     = '1.3'


### PR DESCRIPTION
Changelog:

### Changed
- YouTube track info JSON now gets logged if it does not contain any expected fields.

### Fixed
- Fixed closing MKV Opus track throwing an exception if playback initialization had thrown an exception earlier.
- Fixed exception from track close reported instead of playback exception on MKV close.
- Fixed passing an invalid parameter to YouTube embed page URL.
