### PR TITLE
Return 401/Unauthorized on failed WebSocket Auth

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/HandshakeInterceptorImpl.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/HandshakeInterceptorImpl.kt
@@ -4,6 +4,7 @@ import lavalink.server.config.ServerConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
 import org.springframework.stereotype.Controller
@@ -26,8 +27,6 @@ constructor(private val serverConfig: ServerConfig, private val socketServer: So
      */
     override fun beforeHandshake(request: ServerHttpRequest, response: ServerHttpResponse, wsHandler: WebSocketHandler,
                                  attributes: Map<String, Any>): Boolean {
-        response.headers.add("Lavalink-Major-Version", "3")
-
         val password = request.headers.getFirst("Authorization")
         val matches = password == serverConfig.password
 
@@ -35,6 +34,7 @@ constructor(private val serverConfig: ServerConfig, private val socketServer: So
             log.info("Incoming connection from " + request.remoteAddress)
         } else {
             log.error("Authentication failed from " + request.remoteAddress)
+            response.setStatusCode(HttpStatus.UNAUTHORIZED)
         }
 
         val resumeKey = request.headers.getFirst("Resume-Key")


### PR DESCRIPTION
Currently, Lavalink will respond with status code `200` if authentication fails when attempting to establish a WebSocket connection. As a client library maintainer, this makes it hard to troubleshoot issues when the library is unable to connect to Lavalink. By returning Unauthorized/`401`, the library can check the response code and display an error message about invalid authentication accordingly.

This also removes a line that is made redundant by the `ResponseHeaderFilter`.

With the change:
![](https://serux.pro/b54a102085.png)

Without:
![](https://serux.pro/78db8a25fe.png)