### PR TITLE
Add NaN check to stats

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java
+++ b/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java
@@ -88,8 +88,11 @@ public class StatsTask implements Runnable {
 
         JSONObject cpu = new JSONObject();
         cpu.put("cores", Runtime.getRuntime().availableProcessors());
-        cpu.put("systemLoad", hal.getProcessor().getSystemCpuLoad());
-        double load = getProcessRecentCpuUsage();
+        double load = hal.getProcessor().getSystemCpuLoad();
+        if (!Double.isFinite(load)) load = 0;
+        cpu.put("systemLoad", load);
+
+        load = getProcessRecentCpuUsage();
         if (!Double.isFinite(load)) load = 0;
         cpu.put("lavalinkLoad", load);
 


### PR DESCRIPTION
On some Mac and Windows machines stats can get a NaN for system processor load, which isn't handled very well by stats causing it to break. This change would just replace that with zero. Its not a perfect fix for stats but at least it doesn't throw errors.

Should fix https://github.com/Frederikam/Lavalink/issues/206 