### PR TITLE
Update lavaplayer to 1.3.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     ext {
         //@formatter:off
 
-        lavaplayerVersion               = '1.3.21'
+        lavaplayerVersion               = '1.3.22'
         magmaVersion                    = '0.9.0'
         jdaNasVersion                   = '1.0.6'
         jappVersion                     = '1.3'


### PR DESCRIPTION
This includes a fix for new track formats breaking YouTube track loading.