### PR TITLE
Use non-root user for Docker image

### DIFF
--- a/LavalinkServer/docker/Dockerfile
+++ b/LavalinkServer/docker/Dockerfile
@@ -1,5 +1,10 @@
 FROM openjdk:11-jre-slim
 
+# Run as non-root user
+RUN groupadd -g 322 lavalink && \
+    useradd -r -u 322 -g lavalink lavalink
+USER lavalink
+
 WORKDIR /opt/Lavalink
 
 COPY Lavalink.jar Lavalink.jar


### PR DESCRIPTION
Root container escapes are common. Upon container escape, the attacker will use the UID of 0 and give root access to the host. This change avoids this possibility by using a non-root user to run the lavalink server.