### PR TITLE
Change Magma build slightly

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -34,7 +34,7 @@ bootRun {
 }
 
 dependencies {
-    compile group: 'space.npstr', name: 'Magma', version: magmaVersion
+    compile group: 'space.npstr.Magma', name: 'magma', version: magmaVersion
     compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
     compile group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion
     compile group: 'com.sedmelluq', name: 'jda-nas', version: jdaNasVersion 


### PR DESCRIPTION
Adjusts Magma so that it doesn't compile a blank magma folder that contains a manifest in addition to the normal and operational Magma. The folders have the same name but different capitalization, which causes conflicts on Windows if you want to repack the jar for any reason.