### PR TITLE
Added retryLimit configuration

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -23,6 +23,7 @@ lavalink:
       #excludedIps: ["...", "..."] # ips which should be explicit excluded from usage by lavalink
       #strategy: "RotateOnBan" # RotateOnBan | LoadBalance | NanoSwitch | RotatingNanoSwitch
       #searchTriggersFail: true # Whether a search 429 should trigger marking the ip as failing
+      #retryLimit: -1 # -1 = user default lavaplayer value | 0 = infinity | >0 = retry will happen this numbers times
 
 metrics:
   prometheus:

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -23,7 +23,7 @@ lavalink:
       #excludedIps: ["...", "..."] # ips which should be explicit excluded from usage by lavalink
       #strategy: "RotateOnBan" # RotateOnBan | LoadBalance | NanoSwitch | RotatingNanoSwitch
       #searchTriggersFail: true # Whether a search 429 should trigger marking the ip as failing
-      #retryLimit: -1 # -1 = user default lavaplayer value | 0 = infinity | >0 = retry will happen this numbers times
+      #retryLimit: -1 # -1 = use default lavaplayer value | 0 = infinity | >0 = retry will happen this numbers times
 
 metrics:
   prometheus:

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -48,7 +48,13 @@ class AudioPlayerConfiguration {
         if (sources.isYoutube) {
             val youtube = YoutubeAudioSourceManager(serverConfig.isYoutubeSearchEnabled)
             if (routePlanner != null) {
-                YoutubeIpRotator.setup(youtube, routePlanner)
+                val retryLimit = serverConfig.ratelimit?.retryLimit ?: -1
+                when {
+                    retryLimit < 0 -> YoutubeIpRotator.setup(youtube, routePlanner)
+                    retryLimit == 0 -> YoutubeIpRotator.setup(youtube, routePlanner, Int.MAX_VALUE)
+                    else -> YoutubeIpRotator.setup(youtube, routePlanner, retryLimit)
+
+                }
             }
             val playlistLoadLimit = serverConfig.youtubePlaylistLoadLimit
             if (playlistLoadLimit != null) youtube.setPlaylistPageCount(playlistLoadLimit)

--- a/LavalinkServer/src/main/java/lavalink/server/config/RateLimitConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/RateLimitConfig.kt
@@ -4,5 +4,6 @@ data class RateLimitConfig(
         var ipBlocks: List<String> = emptyList(),
         var excludedIps: List<String> = emptyList(),
         var strategy: String = "RotateOnBan",
+        var retryLimit: Int = -1,
         var searchTriggersFail: Boolean = true
 )


### PR DESCRIPTION
Retry limit configuration, to allow to change the amount of times lavaplayer tries to retry when a ip is blocked.