### PR TITLE
Bump Lavaplayer to 1.3.46

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
 
     ext {
         //@formatter:off
-        lavaplayerVersion               = '1.3.44'
+        lavaplayerVersion               = '1.3.46'
         lavaplayerIpRotatorVersion      = '0.1.7'
         magmaVersion                    = '0.12.6'
         jdaNasVersion                   = '1.1.0'


### PR DESCRIPTION
That time of the year again :P

- Fixes YouTube mix loading.
  - Mix loading is also done in 1 request, so tracks are loaded MUCH quicker than before.
- Fixes YouTube livestream playback.
  - Also adds a retry mechanism so they shouldn't stop after a minute of playback.