### PR TITLE
fix: bump lavaplayer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
 
     ext {
         //@formatter:off
-        lavaplayerVersion               = '1.3.38'
+        lavaplayerVersion               = '1.3.49'
         lavaplayerIpRotatorVersion      = '0.1.7'
         magmaVersion                    = '0.12.5'
         jdaNasVersion                   = '1.1.0'


### PR DESCRIPTION
There don't seem to be any breaking change for Lavalink in the versions in between, however there are some important fixes. In particular in 1.3.43+1.3.44 Soundcloud fixes, 1.3.45 and 1.3.47 YouTube live streams, 1.3.46 Youtube mixes, and in 1.3.49 Twitch playback.
