### PR TITLE
Add playerUpdateInterval option to config

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -15,6 +15,7 @@ lavalink:
       local: false
     bufferDurationMs: 400
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
+    playerUpdateInterval: 5
     youtubeSearchEnabled: true
     soundcloudSearchEnabled: true
     gc-warnings: true

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -15,7 +15,7 @@ lavalink:
       local: false
     bufferDurationMs: 400
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
-    playerUpdateInterval: 5
+    playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds
     youtubeSearchEnabled: true
     soundcloudSearchEnabled: true
     gc-warnings: true

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -33,6 +33,7 @@ class ServerConfig {
     var sentryDsn = ""
     var bufferDurationMs: Int? = null
     var youtubePlaylistLoadLimit: Int? = null
+    var playerUpdateInterval: Int? = null
     var isGcWarnings = true
     var isYoutubeSearchEnabled = true
     var isSoundcloudSearchEnabled = true

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -33,7 +33,7 @@ class ServerConfig {
     var sentryDsn = ""
     var bufferDurationMs: Int? = null
     var youtubePlaylistLoadLimit: Int? = null
-    var playerUpdateInterval: Int? = null
+    var playerUpdateInterval: Int? = 5
     var isGcWarnings = true
     var isYoutubeSearchEnabled = true
     var isSoundcloudSearchEnabled = true

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
@@ -28,6 +28,7 @@ import io.undertow.websockets.core.WebSocketChannel
 import io.undertow.websockets.core.WebSockets
 import io.undertow.websockets.jsr.UndertowSession
 import lavalink.server.player.Player
+import lavalink.server.config.ServerConfig
 import moe.kyokobot.koe.KoeClient
 import moe.kyokobot.koe.KoeEventAdapter
 import moe.kyokobot.koe.VoiceConnection
@@ -46,6 +47,7 @@ import java.util.concurrent.TimeUnit
 
 class SocketContext internal constructor(
         val audioPlayerManager: AudioPlayerManager,
+        val serverConfig: ServerConfig,
         private var session: WebSocketSession,
         private val socketServer: SocketServer,
         val userId: String,
@@ -90,7 +92,7 @@ class SocketContext internal constructor(
     }
 
     internal fun getPlayer(guildId: String) = players.computeIfAbsent(guildId) {
-        Player(this, guildId, audioPlayerManager)
+        Player(this, guildId, audioPlayerManager, serverConfig)
     }
 
     internal fun getPlayers(): Map<String, Player> {

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -89,6 +89,7 @@ class SocketServer(
 
         contextMap[session.id] = SocketContext(
                 audioPlayerManager,
+                serverConfig,
                 session,
                 this,
                 userId,


### PR DESCRIPTION
This PR adds an option to the config (`playerUpdateInterval`) to set the interval for when a playerUpdate WS event is sent, like so:
```
playerUpdateInterval: 3
```
This is useful for cases when, for example, you want to get the current song duration every second or you rarely want to receive said events. As a bit of a side effect, it also adds `serverConfig` as an option to Player which might not be the most optimal solution, so suggestions are appreciated.