### PR TITLE
Update lavaplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+## v3.3.1.3
+* Update lavaplayer to `1.3.53` from devoxin's fork.
+
 ## v3.3.1.2
 * Update lavaplayer to [@Devoxin](https://github.com/Devoxin)'s' fork
 

--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -36,7 +36,7 @@ bootRun {
 dependencies {
     compile group: 'space.npstr.Magma', name: 'magma', version: magmaVersion
     //compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
-    compile group: 'com.github.devoxin', name: 'lavaplayer', version: '1.3.52'
+    compile group: 'com.github.devoxin', name: 'lavaplayer', version: 'a63c541dc5'
     compile group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion
     compile group: 'com.sedmelluq', name: 'jda-nas', version: jdaNasVersion 
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion


### PR DESCRIPTION
This updates LavaLink to 1.3.53 (there's no tag for it). Related to this commit https://github.com/Devoxin/lavaplayer/commit/a63c541dc531ad31b8c9264bf295945753b2d9b7