### PR TITLE
Update LP

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     }
     compile group: 'moe.kyokobot.koe', name: 'ext-udpqueue', version: koeVersion
     //compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
-    compile group: 'com.github.devoxin', name: 'lavaplayer', version: 'a63c541dc5'
+    compile group: 'com.github.devoxin', name: 'lavaplayer', version: '1.3.54.3'
     compile group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion
 


### PR DESCRIPTION
<https://github.com/Devoxin/lavaplayer/releases/tag/1.3.54.3>
- Fixes age-restricted track playback by checking for more player config formats.
  - Less noteworthy, but HTML of tracks w/o a matching player config is now logged to debug.