### PR TITLE
LP 1.54.3 -> 1.3.58

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     }
     compile group: 'moe.kyokobot.koe', name: 'ext-udpqueue', version: koeVersion
     //compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
-    compile group: 'com.github.devoxin', name: 'lavaplayer', version: '1.3.54.3'
+    compile group: 'com.github.devoxin', name: 'lavaplayer', version: '1.3.58'
     compile group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion
 


### PR DESCRIPTION
Summary of changes:
- Fixed searching occasionally emitting an `Failed to match ytInitialData`
- Fixed playback of Bandcamp albums
- Changed behaviour of loading for YT videos that send the new response format; if the JS asset is missing, fall back to loading it from the embed page (Should fix some `NullPointerException`s and missing cipher script issues).
