### PR TITLE
lavaplayer bump: soundcloud fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
 
     ext {
         //@formatter:off
-        lavaplayerVersion               = '1.3.62'
+        lavaplayerVersion               = '1.3.65'
         lavaplayerIpRotatorVersion      = '0.2.3'
         jdaNasVersion                   = '1.1.0'
         jappVersion                     = '1.3.2-MINN'


### PR DESCRIPTION
Bump Lavaplayer to version `1.3.65`
This fixes the broken SoundCloud links