### PR TITLE
docs(readme): add @skyra/audio to client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ users about the compatibility of their clients to the Lavalink server.
 * [erela.js](https://github.com/Solaris9/erela.js) (JavaScript)
 * [Lavacord](https://github.com/lavacord/lavacord) (JavaScript)
 * [LavaJS](https://github.com/OverleapCo/LavaJS) ([discord.js](https://github.com/discordjs/discord.js), JavaScript/TypeScript)
+* [@skyra/audio](https://github.com/skyra-project/audio) ([discord.js](https://github.com/discordjs/discord.js), JavaScript/TypeScript)
 * [EvoLava](https://github.com/EvolveJS/EvoLava) ([EvolveJS](https://github.com/EvolveJS/EvolveJS), Javascript/Typescript)
 * [SharpLink](https://github.com/Devoxin/SharpLink) ([Discord.Net](https://github.com/RogueException/Discord.Net), .NET)
 * [Victoria](https://github.com/Yucked/Victoria) ([Discord.NET](https://github.com/RogueException/Discord.Net), .NET)


### PR DESCRIPTION
For quite a while now we've been using our own client library for [Skyra discord bot](https://top.gg/bot/266624760782258186#/) but it can also totally be used by other people. It just occurred to me only now to add it to the README here. 