### PR TITLE
Bump lavaplayer to 1.3.71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     ext {
         //@formatter:off
         
-        lavaplayerVersion               = '1.3.70'
+        lavaplayerVersion               = '1.3.71'
         lavaplayerIpRotatorVersion      = '0.2.3'
         jdaNasVersion                   = '1.1.0'
         jappVersion                     = '1.3.2-MINN'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     ext {
         //@formatter:off
         
-        lavaplayerVersion               = '1.3.69'
+        lavaplayerVersion               = '1.3.70'
         lavaplayerIpRotatorVersion      = '0.2.3'
         jdaNasVersion                   = '1.1.0'
         jappVersion                     = '1.3.2-MINN'


### PR DESCRIPTION
regression fixes for 1.3.68+
some mp4 formats threw exceptions in those versions