### PR TITLE
Docker: Allow overriding the default command used by the image

### DIFF
--- a/LavalinkServer/docker/Dockerfile
+++ b/LavalinkServer/docker/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /opt/Lavalink
 
 COPY Lavalink.jar Lavalink.jar
 
-ENTRYPOINT ["java", "-Djdk.tls.client.protocols=TLSv1.1,TLSv1.2", "-Xmx4G", "-jar", "Lavalink.jar"]
+CMD ["java", "-Djdk.tls.client.protocols=TLSv1.1,TLSv1.2", "-Xmx4G", "-jar", "Lavalink.jar"]


### PR DESCRIPTION
Currently, the image does not allow setting custom JVM flags (all instances are bound to use `-Xmx4G`), which makes it impossible to tune Lavalink for low memory environments.