### PR TITLE
fix: connected field on playerUpdate is missing

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -62,7 +62,7 @@ class SocketServer(
 
             json.put("op", "playerUpdate")
             json.put("guildId", player.guildId)
-            json.put("state", player.state)
+            json.put("state", state)
             socketContext.send(json)
         }
     }


### PR DESCRIPTION
the connected field isn't set in player.state. so use a declared state variable instead, which the connected field is added there