### PR TITLE
fix: players are not deleted even using destroy op

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
@@ -105,11 +105,12 @@ class SocketContext internal constructor(
     /**
      * Gets or creates a voice connection
      */
-    fun getVoiceConnection(guild: Long): VoiceConnection {
-        var conn = koe.getConnection(guild)
+    fun getVoiceConnection(player: Player): VoiceConnection {
+        val guildId = player.guildId.toLong()
+        var conn = koe.getConnection(guildId)
         if (conn == null) {
-            conn = koe.createConnection(guild)
-            conn.registerListener(EventHandler(guild.toString()))
+            conn = koe.createConnection(guildId)
+            conn.registerListener(EventHandler(player))
         }
         return conn
     }
@@ -181,23 +182,23 @@ class SocketContext internal constructor(
         koe.close()
     }
 
-    private inner class EventHandler(private val guildId: String) : KoeEventAdapter() {
+    private inner class EventHandler(private val player: Player) : KoeEventAdapter() {
         override fun gatewayClosed(code: Int, reason: String?, byRemote: Boolean) {
             val out = JSONObject()
             out.put("op", "event")
             out.put("type", "WebSocketClosedEvent")
-            out.put("guildId", guildId)
+            out.put("guildId", player.guildId)
             out.put("reason", reason ?: "")
             out.put("code", code)
             out.put("byRemote", byRemote)
 
             send(out)
 
-            SocketServer.sendPlayerUpdate(this@SocketContext, this@SocketContext.getPlayer(guildId))
+            SocketServer.sendPlayerUpdate(this@SocketContext, player)
         }
 
         override fun gatewayReady(target: InetSocketAddress?, ssrc: Int) {
-            SocketServer.sendPlayerUpdate(this@SocketContext, this@SocketContext.getPlayer(guildId))
+            SocketServer.sendPlayerUpdate(this@SocketContext, player)
         }
     }
 }

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -57,7 +57,7 @@ class SocketServer(
             val json = JSONObject()
 
             val state = player.state
-            val connected = socketContext.getVoiceConnection(player.guildId.toLong()).gatewayConnection?.isOpen == true
+            val connected = socketContext.getVoiceConnection(player).gatewayConnection?.isOpen == true
             state.put("connected", connected)
 
             json.put("op", "playerUpdate")

--- a/LavalinkServer/src/main/java/lavalink/server/io/WebSocketHandlers.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/WebSocketHandlers.kt
@@ -30,7 +30,7 @@ class WebSocketHandlers(private val contextMap: Map<String, SocketContext>) {
         //discord sometimes send a partial server update missing the endpoint, which can be ignored.
         endpoint ?: return
 
-        context.getVoiceConnection(guildId).connect(VoiceServerInfo(sessionId, endpoint, token))
+        context.getVoiceConnection(context.getPlayer(guildId)).connect(VoiceServerInfo(sessionId, endpoint, token))
     }
 
     fun play(context: SocketContext, json: JSONObject) {
@@ -70,7 +70,7 @@ class WebSocketHandlers(private val contextMap: Map<String, SocketContext>) {
 
         player.play(track)
 
-        val conn = context.getVoiceConnection(player.guildId.toLong())
+        val conn = context.getVoiceConnection(player)
         context.getPlayer(json.getString("guildId")).provideTo(conn)
     }
 


### PR DESCRIPTION
well, the players actually deleted, but when the `gatewayClosed` event emitted, it creates a new one because of `this@SocketContext.getPlayer(guildId)` on the event