### PR TITLE
fix for lavalink not continue playing after voice channel move

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/WebSocketHandlers.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/WebSocketHandlers.kt
@@ -30,7 +30,9 @@ class WebSocketHandlers(private val contextMap: Map<String, SocketContext>) {
         //discord sometimes send a partial server update missing the endpoint, which can be ignored.
         endpoint ?: return
 
-        context.getVoiceConnection(context.getPlayer(guildId)).connect(VoiceServerInfo(sessionId, endpoint, token))
+        val player = context.getPlayer(guildId)
+        val conn = context.getVoiceConnection(player)
+        conn.connect(VoiceServerInfo(sessionId, endpoint, token)).apply { player.provideTo(conn) }
     }
 
     fun play(context: SocketContext, json: JSONObject) {


### PR DESCRIPTION
currently lavalink stops playing when moved to a new voice channel
you need to explicit resume to make it play again. At the same time ll does not send anything to the lavalink-client stating it is paused.
I think resuming would be the best option but I'm open for input from your side.
I'm not sure if you have a better impl for that. Feel free to edit these changes