### PR TITLE
Fix distortion filter typo

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/player/filters/FilterChain.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/filters/FilterChain.kt
@@ -21,7 +21,7 @@ class FilterChain : PcmFilterFactory {
     private val timescale: TimescaleConfig? = null
     private val tremolo: TremoloConfig? = null
     private val vibrato: VibratoConfig? = null
-    private val distorsion: DistortionConfig? = null
+    private val distortion: DistortionConfig? = null
     private val rotation: RotationConfig? = null
 
     private fun buildList() = listOfNotNull(
@@ -31,7 +31,7 @@ class FilterChain : PcmFilterFactory {
             timescale,
             tremolo,
             vibrato,
-            distorsion,
+            distortion,
             rotation
     )
 


### PR DESCRIPTION
The distortion filter was not working (see https://github.com/Frederikam/Lavalink/pull/417#issuecomment-775996087), this PR fixes it.
Thanks `Axel#3456` on JDA server that reported it.