### PR TITLE
source name in track info

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -382,7 +382,8 @@ Response:
         "isStream": false,
         "position": 0,
         "title": "Rick Astley - Never Gonna Give You Up",
-        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "sourceName": "youtube"
       }
     }
   ]

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -439,18 +439,15 @@ Authorization: youshallnotpass
 Response:
 ```json
 {
-  "track": "QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==",
-  "info": {
-    "identifier": "dQw4w9WgXcQ",
-    "isSeekable": true,
-    "author": "RickAstleyVEVO",
-    "length": 212000,
-    "isStream": false,
-    "position": 0,
-    "title": "Rick Astley - Never Gonna Give You Up",
-    "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-    "sourceName": "youtube"
-  }
+  "identifier": "dQw4w9WgXcQ",
+  "isSeekable": true,
+  "author": "RickAstleyVEVO",
+  "length": 212000,
+  "isStream": false,
+  "position": 0,
+  "title": "Rick Astley - Never Gonna Give You Up",
+  "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "sourceName": "youtube"
 }
 ```
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -448,7 +448,8 @@ Response:
     "isStream": false,
     "position": 0,
     "title": "Rick Astley - Never Gonna Give You Up",
-    "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "sourceName": "youtube"
   }
 }
 ```
@@ -481,7 +482,8 @@ Response:
         "isStream": false,
         "position": 0,
         "title": "Rick Astley - Never Gonna Give You Up",
-        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "sourceName": "youtube"
       }
     },
     ...

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -427,6 +427,66 @@ A severity level of `COMMON` indicates that the error is non-fatal and that the 
 }
 ```
 
+### Track Decoding API
+
+Decode a single track into its info
+```
+GET /decodetrack?track=QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA== HTTP/1.1
+Host: localhost:8080
+Authorization: youshallnotpass
+```
+
+Response:
+```json
+{
+  "track": "QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==",
+  "info": {
+    "identifier": "dQw4w9WgXcQ",
+    "isSeekable": true,
+    "author": "RickAstleyVEVO",
+    "length": 212000,
+    "isStream": false,
+    "position": 0,
+    "title": "Rick Astley - Never Gonna Give You Up",
+    "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  }
+}
+```
+
+Decode multiple tracks into info their info
+```
+POST /decodetracks HTTP/1.1
+Host: localhost:8080
+Authorization: youshallnotpass
+```
+
+Request:
+```json
+[
+   "QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==",
+   ...
+]
+```
+
+Response:
+```json
+[
+    {
+      "track": "QAAAjQIAJVJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAADlJpY2tBc3RsZXlWRVZPAAAAAAADPCAAC2RRdzR3OVdnWGNRAAEAK2h0dHBzOi8vd3d3LnlvdXR1YmUuY29tL3dhdGNoP3Y9ZFF3NHc5V2dYY1EAB3lvdXR1YmUAAAAAAAAAAA==",
+      "info": {
+        "identifier": "dQw4w9WgXcQ",
+        "isSeekable": true,
+        "author": "RickAstleyVEVO",
+        "length": 212000,
+        "isStream": false,
+        "position": 0,
+        "title": "Rick Astley - Never Gonna Give You Up",
+        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+      }
+    },
+    ...
+]
+```
 ---
 
 ### RoutePlanner API

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -72,7 +72,8 @@ public class AudioLoaderRestHandler {
                 .put("uri", trackInfo.uri)
                 .put("isStream", trackInfo.isStream)
                 .put("isSeekable", audioTrack.isSeekable())
-                .put("position", audioTrack.getPosition());
+                .put("position", audioTrack.getPosition())
+                .put("sourceName", audioTrack.getSourceManager() == null ? null : audioTrack.getSourceManager().getSourceName());
     }
 
     private JSONObject encodeLoadResult(LoadResult result) {


### PR DESCRIPTION
the track source name is already given in the raw track data and should be useful to also have in the `/loadtracks`, `/decodetrack` & `/decodetracks` endpoints