### PR TITLE
More architectures JDA-NAS

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -21,18 +21,21 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val nasSupported =
             os.contains("linux", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("x86", ignoreCase = true)
+                    || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.
-                    && arch.contains("arm", ignoreCase = true)
+                    || arch.contains("arm", ignoreCase = true)
+                    ||
             os.contains("windows", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("x86", ignoreCase = true)
+                    || arch.equals("x86", ignoreCase = true)
+                    ||
             os.contains("darwin", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("x86", ignoreCase = true)
+                    || arch.equals("x86", ignoreCase = true)
+                    ||
             os.contains("darwin")
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("aarch64", ignoreCase = true)
+                    || arch.equals("aarch64", ignoreCase = true)
 
         if (nasSupported) {
             log.info("Enabling JDA-NAS")

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -24,16 +24,13 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
                     || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.
                     || arch.contains("arm", ignoreCase = true)
+                    || arch.contains("aarch64", ignoreCase = true)
                     ||
-            os.contains("windows", ignoreCase = true)
+                    os.contains("windows", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("x86", ignoreCase = true)
                     ||
-            os.contains("darwin", ignoreCase = true)
-                    && arch.equals("amd64", ignoreCase = true)
-                    || arch.equals("x86", ignoreCase = true)
-                    ||
-            os.contains("darwin")
+                    os.contains("darwin", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("aarch64", ignoreCase = true)
 

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -31,7 +31,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
                     || arch.equals("x86", ignoreCase = true)
                     ||
                     os.contains("darwin", ignoreCase = true)
-                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86_64", ignoreCase = true)
                     || arch.equals("aarch64", ignoreCase = true)
 
         if (nasSupported) {

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -18,9 +18,21 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val os = System.getProperty("os.name")
         val arch = System.getProperty("os.arch")
 
-        // Maybe add Windows natives back?
-        val nasSupported = os.contains("linux", ignoreCase = true)
-                && arch.equals("amd64", ignoreCase = true)
+        val nasSupported =
+            os.contains("linux", ignoreCase = true)
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86", ignoreCase = true)
+                    // Many ARM variants, but should raise lib if it fails to load.
+                    && arch.contains("arm", ignoreCase = true)
+            os.contains("windows", ignoreCase = true)
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86", ignoreCase = true)
+            os.contains("darwin", ignoreCase = true)
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86", ignoreCase = true)
+            os.contains("darwin")
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("aarch64", ignoreCase = true)
 
         if (nasSupported) {
             log.info("Enabling JDA-NAS")

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -19,7 +19,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val arch = System.getProperty("os.arch")
 
         val nasSupported =
-            os.contains("linux", ignoreCase = true)
+                    os.contains("linux", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -24,7 +24,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
                     || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.
                     || arch.contains("arm", ignoreCase = true)
-                    || arch.contains("aarch64", ignoreCase = true)
+                    || arch.equals("aarch64", ignoreCase = true)
                     ||
                     os.contains("windows", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)


### PR DESCRIPTION
Adds support for more architectures, will follow up with PR to udp-queue natives by @aikaterna .

