### PR TITLE
JDA-NAS Toggle

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -13,6 +13,7 @@ lavalink:
       mixer: true
       http: true
       local: false
+    jdanas: true
     bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses
     frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -21,18 +21,21 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val nasSupported =
             os.contains("linux", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("x86", ignoreCase = true)
+                    || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.
-                    && arch.contains("arm", ignoreCase = true)
+                    || arch.contains("arm", ignoreCase = true)
+                    ||
             os.contains("windows", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("x86", ignoreCase = true)
+                    || arch.equals("x86", ignoreCase = true)
+                    ||
             os.contains("darwin", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("x86", ignoreCase = true)
+                    || arch.equals("x86", ignoreCase = true)
+                    ||
             os.contains("darwin")
                     && arch.equals("amd64", ignoreCase = true)
-                    && arch.equals("aarch64", ignoreCase = true)
+                    || arch.equals("aarch64", ignoreCase = true)
 
         if (nasSupported) {
             log.info("Enabling JDA-NAS")

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -24,16 +24,13 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
                     || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.
                     || arch.contains("arm", ignoreCase = true)
+                    || arch.contains("aarch64", ignoreCase = true)
                     ||
-            os.contains("windows", ignoreCase = true)
+                    os.contains("windows", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("x86", ignoreCase = true)
                     ||
-            os.contains("darwin", ignoreCase = true)
-                    && arch.equals("amd64", ignoreCase = true)
-                    || arch.equals("x86", ignoreCase = true)
-                    ||
-            os.contains("darwin")
+                    os.contains("darwin", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("aarch64", ignoreCase = true)
 

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -14,9 +14,9 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
 
     @Bean
     fun koeOptions(): KoeOptions = KoeOptions.builder().apply {
-        log.info("OS: " + System.getProperty("os.name") + ", Arch: " + System.getProperty("os.arch"))
         val os = System.getProperty("os.name")
         val arch = System.getProperty("os.arch")
+        log.info("OS: " + os + ", Arch: " + arch)
 
         val nasSupported =
                     os.contains("linux", ignoreCase = true)
@@ -34,8 +34,10 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("aarch64", ignoreCase = true)
 
-        if (nasSupported) {
-            log.info("Enabling JDA-NAS")
+        val jdaenabled = serverConfig.jdanas
+        if(jdaenabled) {
+            if (nasSupported) {
+            log.info("Enabling JDA-NAS.")
             var bufferSize = serverConfig.bufferDurationMs ?: UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION
             if (bufferSize <= 0) {
                 log.warn("Buffer size of {}ms is illegal. Defaulting to {}",
@@ -46,6 +48,9 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         } else {
             log.warn("This system and architecture appears to not support native audio sending! "
                     + "GC pauses may cause your bot to stutter during playback.")
+        }
+        } else {
+            log.warn("JDA-NAS is disabled.")
         }
     }.create()
 }

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -18,9 +18,21 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val os = System.getProperty("os.name")
         val arch = System.getProperty("os.arch")
 
-        // Maybe add Windows natives back?
-        val nasSupported = os.contains("linux", ignoreCase = true)
-                && arch.equals("amd64", ignoreCase = true)
+        val nasSupported =
+            os.contains("linux", ignoreCase = true)
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86", ignoreCase = true)
+                    // Many ARM variants, but should raise lib if it fails to load.
+                    && arch.contains("arm", ignoreCase = true)
+            os.contains("windows", ignoreCase = true)
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86", ignoreCase = true)
+            os.contains("darwin", ignoreCase = true)
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("x86", ignoreCase = true)
+            os.contains("darwin")
+                    && arch.equals("amd64", ignoreCase = true)
+                    && arch.equals("aarch64", ignoreCase = true)
 
         if (nasSupported) {
             log.info("Enabling JDA-NAS")

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -19,7 +19,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val arch = System.getProperty("os.arch")
 
         val nasSupported =
-            os.contains("linux", ignoreCase = true)
+                    os.contains("linux", ignoreCase = true)
                     && arch.equals("amd64", ignoreCase = true)
                     || arch.equals("x86", ignoreCase = true)
                     // Many ARM variants, but should raise lib if it fails to load.

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -31,6 +31,7 @@ class ServerConfig {
     var password: String? = null
     @get:Deprecated("use {@link SentryConfigProperties} instead.")
     var sentryDsn = ""
+    var jdanas: Boolean = true
     var bufferDurationMs: Int? = null
     var frameBufferDurationMs: Int? = null
     var youtubePlaylistLoadLimit: Int? = null


### PR DESCRIPTION
Makes JDA-NAS togglable.

With in server property jdanas false or true. Depends on #489, also optional. And can be added without that PR. Set to true to mimic default behavior. 

Not sure if there's any other place to document this change. 