### PR TITLE
bump lavaplayer to 1.3.78

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     ext {
         //@formatter:off
         
-        lavaplayerVersion               = '1.3.77'
+        lavaplayerVersion               = '1.3.78'
         lavaplayerIpRotatorVersion      = '0.2.3'
         jdaNasVersion                   = '1.1.0'
         jappVersion                     = '1.3.2-MINN'


### PR DESCRIPTION
lavaplayer 1.3.78 fixes age restricted yt tracks & soundcloud client id issue

https://github.com/sedmelluq/lavaplayer/blob/master/CHANGELOG.md#1378----2021-06-28