### PR TITLE
Update link to application.yml.exemple in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ users about the compatibility of their clients to the Lavalink server.
 ## Server configuration
 Download binaries from [the CI server](https://ci.fredboat.com/viewLog.html?buildId=lastSuccessful&buildTypeId=Lavalink_Build&tab=artifacts&guest=1) or [the GitHub releases](https://github.com/freyacodes/Lavalink/releases).
 
-Put an `application.yml` file in your working directory. [Example](https://github.com/freyacodes/Lavalink/blob/master/LavalinkServer/application.yml.example)
+Put an `application.yml` file in your working directory. [Example](https://github.com/freyacodes/Lavalink/blob/3.3.2.5/LavalinkServer/application.yml.example)
 
 Run with `java -jar Lavalink.jar`
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ users about the compatibility of their clients to the Lavalink server.
 ## Server configuration
 Download binaries from [the CI server](https://ci.fredboat.com/viewLog.html?buildId=lastSuccessful&buildTypeId=Lavalink_Build&tab=artifacts&guest=1) or [the GitHub releases](https://github.com/freyacodes/Lavalink/releases).
 
-Put an `application.yml` file in your working directory. [Example](https://github.com/freyacodes/Lavalink/blob/3.3.2.5/LavalinkServer/application.yml.example)
+Put an `application.yml` file in your working directory. [Example](https://github.com/freyacodes/Lavalink/blob/master/LavalinkServer/application.yml.example)
 
 Run with `java -jar Lavalink.jar`
 


### PR DESCRIPTION
The actual link is still linking to the old owner's name.
Now owned by a troll.
This PR updates the link in the readme.md