### PR TITLE
bump lavaplayer latest version of walkyst fork

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -39,8 +39,11 @@ dependencies {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
     compile group: 'moe.kyokobot.koe', name: 'ext-udpqueue', version: koeVersion
-    compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
-    compile group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion
+    compile group: 'com.github.Walkyst', name: 'lavaplayer-fork', version: '9ed7db57f4'
+    //compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
+    compile(group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion) {
+        exclude group: 'com.sedmelluq', module: 'lavaplayer'
+    }
     compile group: 'com.github.natanbc', name: 'lavadsp', version: lavaDspVersion
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion
 

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -8,7 +8,7 @@ import com.sedmelluq.discord.lavaplayer.source.http.HttpAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.local.LocalAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.DefaultSoundCloudDataReader
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.DefaultSoundCloudFormatHandler
-import com.sedmelluq.discord.lavaplayer.source.soundcloud.DefaultSoundCloudHtmlDataLoader
+import com.sedmelluq.discord.lavaplayer.source.soundcloud.DefaultSoundCloudDataLoader
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.DefaultSoundCloudPlaylistLoader
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager
@@ -73,15 +73,15 @@ class AudioPlayerConfiguration {
         }
         if (sources.isSoundcloud) {
             val dataReader = DefaultSoundCloudDataReader();
-            val htmlDataLoader = DefaultSoundCloudHtmlDataLoader();
+            val dataLoader = DefaultSoundCloudDataLoader();
             val formatHandler = DefaultSoundCloudFormatHandler();
 
             audioPlayerManager.registerSourceManager(SoundCloudAudioSourceManager(
                     serverConfig.isSoundcloudSearchEnabled,
                     dataReader,
-                    htmlDataLoader,
+                    dataLoader,
                     formatHandler,
-                    DefaultSoundCloudPlaylistLoader(htmlDataLoader, dataReader, formatHandler)
+                    DefaultSoundCloudPlaylistLoader(dataLoader, dataReader, formatHandler)
             ));
         }
         if (sources.isBandcamp) audioPlayerManager.registerSourceManager(BandcampAudioSourceManager())


### PR DESCRIPTION
as sed is currently gone again we might use walkyst fork
they made general changes in their fork which are msotly removed in the [original branch](https://github.com/Walkyst/lavaplayer-fork/tree/original) except the rename of `SoundCloudHtmlDataLoader` to `SoundCloudDataLoader` & their implementation

this should fix soundcloud &  age restricted yt tracks once again