### PR TITLE
add missing erelajs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ users about the compatibility of their clients to the Lavalink server.
 * [eris-lavalink](https://github.com/briantanner/eris-lavalink) ([eris](https://github.com/abalabahaha/eris), JavaScript)
 * [LavaClient](https://github.com/lavaclient/lavaclient) (JavaScript)
 * [Shoukaku](https://github.com/Deivu/Shoukaku) ([discord.js](https://github.com/discordjs/discord.js), JavaScript)
+* [erela.js](https://github.com/MenuDocs/erela.js) (JavaScript)
 * [Lavacord](https://github.com/lavacord/lavacord) (JavaScript)
 * [LavaJS](https://github.com/Overleap/LavaJS) ([discord.js](https://github.com/discordjs/discord.js), JavaScript/TypeScript)
 * [EvoLava](https://github.com/EvolveJS/EvoLava) ([EvolveJS](https://github.com/EvolveJS/EvolveJS), Javascript/Typescript)


### PR DESCRIPTION
don't know if this is intentional, but it seems the dev version of the readme does not include erela.js as a known library