### PR TITLE
Added lavasnek_rs to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ users about the compatibility of their clients to the Lavalink server.
 * [Magma](https://github.com/initzx/magma/) (discord.py, Python)
 * [lavapotion](https://github.com/SamOphis/lavapotion) (Elixir)
 * [WaveLink](https://github.com/EvieePy/Wavelink) (discord.py, Python)
-* [Lavalink-rs](https://gitlab.com/nitsuga5124/lavalink-rs/) (Async Libraries, Rust)
+* [Lavalink-rs](https://gitlab.com/nitsuga5124/lavalink-rs/) (All `tokio` Libraries, Rust)
+* [lavasnek_rs](https://github.com/vicky5124/lavasnek_rs/) (All `asyncio` Libraries, Python)
 * Or [create your own](https://github.com/freyacodes/Lavalink/blob/master/IMPLEMENTATION.md)
 
 ## Server configuration

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ users about the compatibility of their clients to the Lavalink server.
 * [Magma](https://github.com/initzx/magma/) (discord.py, Python)
 * [lavapotion](https://github.com/SamOphis/lavapotion) (Elixir)
 * [WaveLink](https://github.com/EvieePy/Wavelink) (discord.py, Python)
-* [Lavalink-rs](https://gitlab.com/nitsuga5124/lavalink-rs/) (All `tokio` Libraries, Rust)
+* [Lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs/) (All `tokio` Libraries, Rust)
 * [lavasnek_rs](https://github.com/vicky5124/lavasnek_rs/) (All `asyncio` Libraries, Python)
 * Or [create your own](https://github.com/freyacodes/Lavalink/blob/master/IMPLEMENTATION.md)
 


### PR DESCRIPTION
Added a python library, based on lavalink-rs, that's compatible with all python `asyncio` based libraries, like Hikari, discord.py(and forks) or Hata, while also being able to run standalone.

	modified:   README.md