### PR TITLE
Fix: when the player gets moved into another channel the session is r…

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/WebSocketHandlers.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/WebSocketHandlers.kt
@@ -26,6 +26,10 @@ class WebSocketHandlers(private val contextMap: Map<String, SocketContext>) {
         endpoint ?: return
 
         context.getVoiceConnection(guildId).connect(VoiceServerInfo(sessionId, endpoint, token))
+
+        //fix: when the player gets moved into another channel the session is resumed but no audio is played.
+        val conn = context.getVoiceConnection(guildId)
+        context.getPlayer(guildId.toString()).provideTo(conn)
     }
 
     fun play(context: SocketContext, json: JSONObject) {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ allprojects {
         mavenLocal()                       // useful for developing
         maven { url "https://jitpack.io" } // build projects directly from github
         maven { url 'https://dl.bintray.com/sedmelluq/com.sedmelluq' }
+        maven {
+            url 'https://m2.dv8tion.net/releases'
+        }
     }
 
     group = 'lavalink'


### PR DESCRIPTION
Hi, I would like to do this pull request because when the player gets moved into another channel (i'm currently using Lavalink.py and Discord.py for my bot) the session is resumed but no audio is played in the channel.

Hope it helps.

Regards.