### PR TITLE
Fix error when enabling timescale and lowpass filters

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/player/filters/filterConfigs.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/filters/filterConfigs.kt
@@ -160,7 +160,7 @@ class LowPassConfig(
     private val smoothing: Float = 20.0f
 ) : FilterConfig() {
     override fun build(format: AudioDataFormat, output: FloatPcmAudioFilter): FloatPcmAudioFilter {
-        return LowPassPcmAudioFilter(output, format.sampleRate)
+        return LowPassPcmAudioFilter(output, format.channelCount)
             .setSmoothing(smoothing)
     }
 


### PR DESCRIPTION
The `sampleRate` parameter was being passed to lavadsp LowPassPcmAudioFilter constructor instead of `channelCount` causing the error:
`Index 2 out of bounds for length 2` on lavadsp when enabling timescale and lowpass filters at the same time.

Closes #491