### PR TITLE
Bump oshi version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
         springWebSocketVersion          = '5.1.9.RELEASE'
         logbackVersion                  = '1.2.3'
         sentryLogbackVersion            = '1.7.7'
-        oshiVersion                     = '5.7.4'
+        oshiVersion                     = '5.8.7'
         jsonOrgVersion                  = '20180813'
         spotbugsAnnotationsVersion      = '3.1.6'
         prometheusVersion               = '0.5.0'


### PR DESCRIPTION
I have a user that is using a 64-bit Windows 10 device to host Lavalink and his bot, and he encountered a stats issue/oshi issue when using a Lavalink.jar with oshi 5.7.4, this can be seen in his log at https://gist.githubusercontent.com/Cog-CreatorsBot/93ac8762eee30fed0b661f4f04fd7a3e/raw/3325e473fc269fae52350bd1d7b940fe6470e076/spring_1.log

```
2022-01-06 18:17:33.597  WARN 4508 --- [pool-2-thread-1] o.util.platform.windows.WmiQueryHandler  : COM exception: Invalid Query: SELECT NAME,PRIORITY,CREATIONDATE,PROCESSID,PARENTPROCESSID,READTRANSFERCOUNT,WRITETRANSFERCOUNT,PRIVATEPAGECOUNT,PAGEFAULTSPERSEC FROM Win32_Process WHERE NOT Name LIKE"%_Total"
```

This issue is reported in https://github.com/oshi/oshi/issues/1710 and resolved with release 5.8.2. I did not bump oshi to 6.0.0 in case there were major breakages or changes with that version, and my user has tested a Lavalink.jar with oshi 5.8.7 on the problematic machine - at the end of the logs I linked there is a Lavalink Spring Boot header where the branch name is `oshi-experimental-fix`, and the stats issues are resolved in that log/not present.

I have tested this change on an intel Mac with AdoptOpenJDK v 11.0.9 and a 64-bit Linux device running Ubuntu 20.04.3 LTS with Azul Java v 13.0.6 and have not noticed any issues, however I am not knowledgeable in Java and I am not sure if there are any other concerns with bumping this dependency to this version. 