### PR TITLE
Correctly emit 'FINISHED' in TrackEndEvent for TrackEndMarkers

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/EventEmitter.java
@@ -75,7 +75,12 @@ public class EventEmitter extends AudioEventAdapter {
             out.put("track", JSONObject.NULL);
         }
 
-        out.put("reason", endReason.toString());
+        if (linkPlayer.getEndMarkerHit()) {
+            out.put("reason", AudioTrackEndReason.FINISHED.toString());
+            linkPlayer.setEndMarkerHit(false);
+        } else {
+            out.put("reason", endReason.toString());
+        }
 
         linkPlayer.getSocket().send(out);
     }

--- a/LavalinkServer/src/main/java/lavalink/server/player/Player.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/Player.java
@@ -57,6 +57,7 @@ public class Player extends AudioEventAdapter implements IPlayer {
     private AudioFrame lastFrame = null;
     private FilterChain filters;
     private ScheduledFuture<?> myFuture = null;
+    private boolean endMarkerHit = false;
 
     public Player(SocketContext socketContext, long guildId, AudioPlayerManager audioPlayerManager, ServerConfig serverConfig) {
         this.socketContext = socketContext;
@@ -115,6 +116,14 @@ public class Player extends AudioEventAdapter implements IPlayer {
 
     public void setVolume(int volume) {
         player.setVolume(volume);
+    }
+
+    public void setEndMarkerHit(boolean hit) {
+        this.endMarkerHit = hit;
+    }
+
+    public boolean getEndMarkerHit() {
+        return this.endMarkerHit;
     }
 
     public JSONObject getState() {

--- a/LavalinkServer/src/main/java/lavalink/server/player/TrackEndMarkerHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/TrackEndMarkerHandler.java
@@ -34,7 +34,9 @@ public class TrackEndMarkerHandler implements TrackMarkerHandler {
 
     @Override
     public void handle(MarkerState state) {
-        if (state.equals(MarkerState.REACHED) | state.equals(MarkerState.BYPASSED))
+        if (state.equals(MarkerState.REACHED) | state.equals(MarkerState.BYPASSED)) {
+            player.setEndMarkerHit(true);
             player.stop();
+        }
     }
 }


### PR DESCRIPTION
This PR introduces an `endMarkerHit` boolean within `linkPlayer` which is set to `true` by the `TrackEndMarkerHandler` class when the provided `endTime` is hit (if applicable).

This boolean is then used by the `EventEmitter` class to establish whether to emit the *true* end reason, or `FINISHED`. This is necessary as most libraries use the `reason` in the `TrackEndEvent` to determine whether or not they should play the next song in queue, to avoid unintended behaviour such as double-skipping or playing when a `stop` command has been called, for example.

This seemed like the cleanest way to implement this solution for **#569**, as this should work for all tracks including livestreams.
I wasn't sure whether to implement a custom reason (such as `END_MARKER_HIT`) so libraries could optionally implement special handling or user-facing messages so I opted for the safe route of emitting `FINISHED`, though I can change this upon request.

As always, feedback is welcomed! :)