### PR TITLE
Allow adding new MediaContainerProbes via plugins

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -60,7 +60,7 @@ class MyAudioSourceManager implements AudioSourceManager {
 } 
 ```
 
-Likewise, if you just want to add a new MediaContainerProbe to use with the HTTP and local sources:
+Likewise, you can also add new MediaContainerProbe this way, to be used with the HTTP and local sources:
 
 ```java
 import org.springframework.stereotype.Service;

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -59,3 +59,14 @@ class MyAudioSourceManager implements AudioSourceManager {
     // ...
 } 
 ```
+
+Likewise, if you just want to add a new MediaContainerProbe to use with the HTTP and local sources:
+
+```java
+import org.springframework.stereotype.Service;
+
+@Service
+class MyMediaContainerProbe implements MediaContainerProbe {
+    // ...
+} 
+```


### PR DESCRIPTION
Just a small edit to `AudioPlayerConfiguration` that adds the ability to add new `MediaContainerProbe` instances. This is useful for adding support for new HTTP/local file formats or adding a new source that depends on some sort of weird codec.