### PR TITLE
Update spring dependencies

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -12,6 +12,7 @@ apply plugin: "com.adarshr.test-logger"
 description = 'Play audio to discord voice channels'
 mainClassName = "lavalink.server.Launcher"
 version = "${versionFromTag()}".toString()
+
 ext {
     moduleName = 'Lavalink-Server'
 }
@@ -20,6 +21,7 @@ ext {
 def versionVal = version
 
 bootJar {
+    archiveFileName = "Lavalink.jar"
     doLast {
         //copies the jar into a place where the Dockerfile can find it easily (and users maybe too)
         copy {
@@ -45,38 +47,44 @@ bootRun {
     }
 }
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 dependencies {
-    compile project(":plugin-api")
-    compile (group: 'moe.kyokobot.koe', name: 'core', version: koeVersion) {
+    implementation project(":plugin-api")
+    implementation (group: 'moe.kyokobot.koe', name: 'core', version: koeVersion) {
         // This version of SLF4J does not recognise Logback 1.2.3
         exclude group: "org.slf4j", module: "slf4j-api"
     }
-    compile group: 'moe.kyokobot.koe', name: 'ext-udpqueue', version: koeVersion
-    compile group: 'com.github.walkyst', name: 'lavaplayer-fork', version: lavaplayerVersion
+    implementation group: 'moe.kyokobot.koe', name: 'ext-udpqueue', version: koeVersion
+    implementation group: 'com.github.walkyst', name: 'lavaplayer-fork', version: lavaplayerVersion
 
-    //compile group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
-    compile(group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion) {
+    //implementation group: 'com.sedmelluq', name: 'lavaplayer', version: lavaplayerVersion
+    implementation(group: 'com.sedmelluq', name: 'lavaplayer-ext-youtube-rotator', version: lavaplayerIpRotatorVersion) {
         exclude group: 'com.sedmelluq', module: 'lavaplayer'
     }
-    compile group: 'com.github.natanbc', name: 'lavadsp', version: lavaDspVersion
-    compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion
+    implementation group: 'com.github.natanbc', name: 'lavadsp', version: lavaDspVersion
+    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion
 
-    compile group: 'org.springframework', name: 'spring-websocket', version: springWebSocketVersion
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
-    compile group: 'io.sentry', name: 'sentry-logback', version: sentryLogbackVersion
-    compile group: 'com.github.oshi', name: 'oshi-core', version: oshiVersion
-    compile group: 'org.json', name: 'json', version: jsonOrgVersion
-    compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
-    compile(group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion) {
+    implementation group: 'org.springframework', name: 'spring-websocket', version: springWebSocketVersion
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+    implementation group: 'io.sentry', name: 'sentry-logback', version: sentryLogbackVersion
+    implementation group: 'com.github.oshi', name: 'oshi-core', version: oshiVersion
+    implementation group: 'org.json', name: 'json', version: jsonOrgVersion
+    implementation group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+    implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion) {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     }
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-undertow', version: springBootVersion
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-undertow', version: springBootVersion
     compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsAnnotationsVersion
 
-    compile group: 'io.prometheus', name: 'simpleclient', version: prometheusVersion
-    compile group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
-    compile group: 'io.prometheus', name: 'simpleclient_logback', version: prometheusVersion
-    compile group: 'io.prometheus', name: 'simpleclient_servlet', version: prometheusVersion
+    implementation group: 'io.prometheus', name: 'simpleclient', version: prometheusVersion
+    implementation group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
+    implementation group: 'io.prometheus', name: 'simpleclient_logback', version: prometheusVersion
+    implementation group: 'io.prometheus', name: 'simpleclient_servlet', version: prometheusVersion
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
 }
@@ -109,6 +117,10 @@ compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }
 
 @SuppressWarnings("GrMethodMayBeStatic")

--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -22,15 +22,6 @@ def versionVal = version
 
 bootJar {
     archiveFileName = "Lavalink.jar"
-    doLast {
-        //copies the jar into a place where the Dockerfile can find it easily (and users maybe too)
-        copy {
-            from("build/libs/Lavalink-Server-${versionVal}.jar")
-            into("build/libs/")
-
-            rename(".*", "Lavalink.jar")
-        }
-    }
 }
 
 sourceCompatibility = targetCompatibility = 11

--- a/LavalinkServer/src/test/java/lavalink/server/config/RequestAuthorizationFilterTest.java
+++ b/LavalinkServer/src/test/java/lavalink/server/config/RequestAuthorizationFilterTest.java
@@ -2,13 +2,13 @@ package lavalink.server.config;
 
 
 import lavalink.server.info.AppInfo;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Created by napster on 08.03.19.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc
 @SpringBootTest()
 @ActiveProfiles({"test"})

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.8.RELEASE'
+        springBootVersion = '2.6.6'
         gradleGitVersion = '1.5.2'
         sonarqubeVersion = '2.6.2'
         kotlinVersion = '1.3.61'
@@ -62,7 +62,7 @@ subprojects {
         lavaDspVersion                  = '0.7.7'
 
         springBootVersion               = "${springBootVersion}"
-        springWebSocketVersion          = '5.1.9.RELEASE'
+        springWebSocketVersion          = '5.3.17'
         logbackVersion                  = '1.2.3'
         sentryLogbackVersion            = '1.7.7'
         oshiVersion                     = '5.7.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This commit should tackle any possibility of CVE-2022-22965 being exploited on LavaLink. As far as the current information available states, LavaLink is not vulnerable as we are using the Undertow container and running as a deployable jar instead of a war-file.

More information is available on spring's blog: [https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement](https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement).

This dependency update required an upgrade to Gradle 6.9 as the spring-boot dependency now requires at least gradle 6.8, since 7.0 made changes to how a lot of APIs work, I've sticked with 6.9 for now.