### PR TITLE
Add log message when application is ready

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent
 import org.springframework.boot.context.event.ApplicationFailedEvent
+import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.ComponentScan
@@ -148,6 +149,11 @@ object Launcher {
                 ApplicationListener { event: Any ->
                     if (event is ApplicationEnvironmentPreparedEvent) {
                         log.info(getVersionInfo())
+                    }
+                },
+                ApplicationListener { event: Any ->
+                    if (event is ApplicationReadyEvent) {
+                        log.info("Application is ready to accept connections.")
                     }
                 },
                 ApplicationListener { event: Any ->

--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
@@ -153,7 +153,7 @@ object Launcher {
                 },
                 ApplicationListener { event: Any ->
                     if (event is ApplicationReadyEvent) {
-                        log.info("Application is ready to accept connections.")
+                        log.info("Lavalink is ready to accept connections.")
                     }
                 },
                 ApplicationListener { event: Any ->


### PR DESCRIPTION
This new log message marks the moment the application is ready more clearly now that there are 2 'Started Launcher' log messages (a result of there now being two spring applications - PluginManager and LavalinkApplication).

Additionally, this is somewhat helpful for people running LL through subprocesses that want to programmatically detect when the application starts to accept connections [such as we do over at Red](https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/cogs/audio/manager.py) as it's probably more reliable over checking that "Started Launcher" message was logged twice which is probably somewhat more likely to change in future as it depends on spring init.