### PR TITLE
Fix docker folder perms

### DIFF
--- a/LavalinkServer/docker/Dockerfile
+++ b/LavalinkServer/docker/Dockerfile
@@ -3,9 +3,12 @@ FROM azul/zulu-openjdk:13
 # Run as non-root user
 RUN groupadd -g 322 lavalink && \
     useradd -r -u 322 -g lavalink lavalink
-USER lavalink
 
 WORKDIR /opt/Lavalink
+
+RUN chown -R lavalink:lavalink /opt/Lavalink
+
+USER lavalink
 
 COPY Lavalink.jar Lavalink.jar
 


### PR DESCRIPTION
the lavalink user can't create the `/opt/Lavalink/plugins` folder due to permission issues

this should fix this