### PR TITLE
Narrow wavelink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Client | Platform | Compatible With | Additional Information
 [Lavalink.py](https://github.com/Devoxin/Lavalink.py) | Python | **Any**
 [lavasnek_rs](https://github.com/vicky5124/lavasnek_rs) | Python | **Any\*** | *`asyncio`-based libraries only
 [lavaplayer-py](https://github.com/HazemMeqdad/lavaplayer) | Python | **Any\*** | *`asyncio`-based libraries only
-[Wavelink](https://github.com/PythonistaGuild/Wavelink) | Python | discord.py/**Any\*** | *`discord`-namespace/`discord.py`-derived libraries only
+[Wavelink](https://github.com/PythonistaGuild/Wavelink) | Python | discord.py **V2**
 [Pomice](https://github.com/cloudwithax/pomice) | Python | discord.py/**Any\*** | *`discord`-namespace/`discord.py`-derived libraries only
 [Slate](https://github.com/Axelware/slate) | Python | discord.py/**Any\*** | *`discord`-namespace/`discord.py`-derived libraries only
 [Lavapy](https://github.com/Aspect1103/Lavapy) | Python | discord.py


### PR DESCRIPTION
With discord.py resuming development, we have dropped support for discord.py forks, and now only support discord.py V2