### PR TITLE
Enforce minimum bufferDuration of 50ms

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -12,7 +12,7 @@ lavalink:
       vimeo: true
       http: true
       local: false
-    bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses
+    bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Minimum of 40ms, lower values may introduce more pauses.
     frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
     playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -12,7 +12,7 @@ lavalink:
       vimeo: true
       http: true
       local: false
-    bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Minimum of 40ms, lower values may introduce more pauses.
+    bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Minimum of 40ms, lower values may introduce pauses.
     frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
     playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -25,7 +25,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         if (nasSupported) {
             log.info("Enabling JDA-NAS")
             var bufferSize = serverConfig.bufferDurationMs ?: UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION
-            if (bufferSize <= 50) {
+            if (bufferSize < 50) {
                 log.warn("Buffer size of {}ms is illegal. Defaulting to {}",
                         bufferSize, UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION)
                 bufferSize = UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -25,7 +25,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         if (nasSupported) {
             log.info("Enabling JDA-NAS")
             var bufferSize = serverConfig.bufferDurationMs ?: UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION
-            if (bufferSize <= 0) {
+            if (bufferSize <= 50) {
                 log.warn("Buffer size of {}ms is illegal. Defaulting to {}",
                         bufferSize, UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION)
                 bufferSize = UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -25,7 +25,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         if (nasSupported) {
             log.info("Enabling JDA-NAS")
             var bufferSize = serverConfig.bufferDurationMs ?: UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION
-            if (bufferSize < 50) {
+            if (bufferSize < 60) {
                 log.warn("Buffer size of {}ms is illegal. Defaulting to {}",
                         bufferSize, UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION)
                 bufferSize = UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -25,7 +25,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         if (nasSupported) {
             log.info("Enabling JDA-NAS")
             var bufferSize = serverConfig.bufferDurationMs ?: UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION
-            if (bufferSize < 60) {
+            if (bufferSize < 40) {
                 log.warn("Buffer size of {}ms is illegal. Defaulting to {}",
                         bufferSize, UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION)
                 bufferSize = UdpQueueFramePollerFactory.DEFAULT_BUFFER_DURATION


### PR DESCRIPTION
Fixes #627 

Any values <20ms cause Lavalink to not output audio.
Values equal to 20ms cause intermittent stuttering.
40ms and higher seem to be viable values, so have settled on 50ms to offer Lavalink a bit of headroom.