### PR TITLE
enable jda nas for more architectures

### DIFF
--- a/LavalinkServer/build.gradle.kts
+++ b/LavalinkServer/build.gradle.kts
@@ -45,7 +45,10 @@ dependencies {
         // This version of SLF4J does not recognise Logback 1.2.3
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
-    implementation(libs.koe.udpqueue)
+    implementation(libs.koe.udpqueue) {
+        exclude(module="udp-queue")
+    }
+    implementation(libs.bundles.udpqueue.natives)
 
     implementation(libs.lavaplayer)
     implementation(libs.lavaplayer.ip.rotator)

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -18,9 +18,9 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
         val os = System.getProperty("os.name")
         val arch = System.getProperty("os.arch")
 
-        // Maybe add Windows natives back?
-        val nasSupported = os.contains("linux", ignoreCase = true)
-                && arch.equals("amd64", ignoreCase = true)
+        // Filter darwin m1 out
+        val nasSupported = !os.contains("darwin", ignoreCase = true)
+                && !arch.equals("aarch64", ignoreCase = true)
 
         if (nasSupported) {
             log.info("Enabling JDA-NAS")

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -1,5 +1,8 @@
 package lavalink.server.config
 
+import com.sedmelluq.lava.common.natives.architecture.DefaultArchitectureTypes
+import com.sedmelluq.lava.common.natives.architecture.DefaultOperatingSystemTypes
+import com.sedmelluq.lava.common.natives.architecture.SystemType
 import moe.kyokobot.koe.KoeOptions
 import moe.kyokobot.koe.codec.udpqueue.UdpQueueFramePollerFactory
 import org.slf4j.Logger
@@ -11,16 +14,29 @@ import org.springframework.context.annotation.Configuration
 class KoeConfiguration(val serverConfig: ServerConfig) {
 
     private val log: Logger = LoggerFactory.getLogger(KoeConfiguration::class.java)
+    private val supportedSystems = listOf(
+        SystemType(DefaultArchitectureTypes.ARM, DefaultOperatingSystemTypes.LINUX),
+        SystemType(DefaultArchitectureTypes.X86_64, DefaultOperatingSystemTypes.LINUX),
+        SystemType(DefaultArchitectureTypes.X86_32, DefaultOperatingSystemTypes.LINUX),
+        SystemType(DefaultArchitectureTypes.ARMv8_64, DefaultOperatingSystemTypes.LINUX),
+
+        SystemType(DefaultArchitectureTypes.X86_64, DefaultOperatingSystemTypes.WINDOWS),
+        SystemType(DefaultArchitectureTypes.X86_32, DefaultOperatingSystemTypes.WINDOWS),
+
+        SystemType(DefaultArchitectureTypes.X86_64, DefaultOperatingSystemTypes.DARWIN),
+        SystemType(DefaultArchitectureTypes.ARMv8_64, DefaultOperatingSystemTypes.DARWIN)
+    )
 
     @Bean
     fun koeOptions(): KoeOptions = KoeOptions.builder().apply {
-        log.info("OS: " + System.getProperty("os.name") + ", Arch: " + System.getProperty("os.arch"))
-        val os = System.getProperty("os.name")
-        val arch = System.getProperty("os.arch")
+        val systemType: SystemType? = try {
+            SystemType(DefaultArchitectureTypes.detect(), DefaultOperatingSystemTypes.detect())
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+        log.info("OS: ${systemType?.osType ?: "unknown"}, Arch: ${systemType?.architectureType ?: "unknown"}")
 
-        // Filter darwin m1 out
-        val nasSupported = !os.contains("darwin", ignoreCase = true)
-                && !arch.equals("aarch64", ignoreCase = true)
+        val nasSupported = supportedSystems.any { it.osType == systemType?.osType && it.architectureType == systemType?.architectureType }
 
         if (nasSupported) {
             log.info("Enabling JDA-NAS")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,14 @@ fun VersionCatalogBuilder.voice() {
 
     library("koe",          "moe.kyokobot.koe", "core").version("2.0.0-rc1")
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").version("2.0.0-rc1")
+
+    version("udpqueue", "0.1.5")
+    val platforms = listOf("linux-x86-64", "linux-x86", "linux-aarch64", "linux-arm", "win-x86-64", "win-x86", "darwin")
+    platforms.forEach {
+        library("udpqueue-native-$it", "club.minnced", "udpqueue-native-$it").versionRef("udpqueue")
+    }
+
+    bundle("udpqueue-natives", platforms.map { "udpqueue-native-$it" })
 }
 
 fun VersionCatalogBuilder.metrics() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,7 @@ fun VersionCatalogBuilder.voice() {
     library("koe",          "moe.kyokobot.koe", "core").version("2.0.0-rc1")
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").version("2.0.0-rc1")
 
-    version("udpqueue", "0.1.5")
+    version("udpqueue", "0.1.6")
     val platforms = listOf("linux-x86-64", "linux-x86", "linux-aarch64", "linux-arm", "win-x86-64", "win-x86", "darwin")
     platforms.forEach {
         library("udpqueue-native-$it", "club.minnced", "udpqueue-native-$it").versionRef("udpqueue")


### PR DESCRIPTION
this adds jda nas support for the following architectures:
```
linux-x86
linux-aarch64
linux-arm
win-x86-64
win-x86
darwin
```

~~m1 support is currently missing~~this has been added