### PR TITLE
Allow adjustment of opus encoding & resampling quality fields in AudioConfiguration

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -16,7 +16,8 @@ lavalink:
     frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
     opusEncodingQuality: 10 # Opus encoder quality. Valid values range from 0 to 10, where 10 is best quality but is the most expensive on the CPU.
     resamplingQuality: LOW # Quality of resampling operations. Valid values are LOW, MEDIUM and HIGH, where HIGH uses the most CPU.
-    trackStuckThresholdMs: 10000  # The threshold for how long a track can be stuck. A track is stuck if does not return any audio data.
+    trackStuckThresholdMs: 10000 # The threshold for how long a track can be stuck. A track is stuck if does not return any audio data.
+    useSeekGhosting: true # Seek ghosting is the effect where whilst a seek is in progress, the audio buffer is read from until empty, or until seek is ready.
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
     playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds
     youtubeSearchEnabled: true

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -14,6 +14,8 @@ lavalink:
       local: false
     bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Minimum of 40ms, lower values may introduce pauses.
     frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
+    opusEncodingQuality: 10 # Opus encoder quality. Valid values range from 0 to 10, where 10 is best quality but is the most expensive on the CPU.
+    resamplingQuality: LOW # Quality of resampling operations. Valid values are LOW, MEDIUM and HIGH, where HIGH uses the most CPU.
     trackStuckThresholdMs: 10000  # The threshold for how long a track can be stuck. A track is stuck if does not return any audio data.
     youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
     playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -2,6 +2,8 @@ package lavalink.server.config
 
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerRegistry
+import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration
+import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration.ResamplingQuality
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager
@@ -63,6 +65,24 @@ class AudioPlayerConfiguration {
             val bufferDuration = it.takeIf { it >= 200 } ?: defaultFrameBufferDuration
             log.debug("Setting frame buffer duration to {}", bufferDuration)
             audioPlayerManager.frameBufferDuration = bufferDuration
+        }
+
+        val defaultOpusEncodingQuality = AudioConfiguration.OPUS_QUALITY_MAX
+        audioPlayerManager.configuration.let {
+            serverConfig.opusEncodingQuality?.let { opusQuality ->
+                if (opusQuality !in 0..10) {
+                    log.warn("Opus encoding quality {} is not within the range of 0 to 10. Defaulting to {}", opusQuality, defaultOpusEncodingQuality)
+                }
+
+                val qualitySetting = opusQuality.takeIf { it in 0..10 } ?: defaultOpusEncodingQuality
+                log.debug("Setting opusEncodingQuality to {}", qualitySetting)
+                it.opusEncodingQuality = qualitySetting
+            }
+
+            serverConfig.resamplingQuality.let { resamplingQuality ->
+                log.debug("Setting resamplingQuality to {}", resamplingQuality)
+                it.resamplingQuality = resamplingQuality
+            }
         }
 
         val defaultTrackStuckThresholdMs = TimeUnit.NANOSECONDS.toMillis(audioPlayerManager.trackStuckThresholdNanos)

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -79,7 +79,7 @@ class AudioPlayerConfiguration {
                 it.opusEncodingQuality = qualitySetting
             }
 
-            serverConfig.resamplingQuality.let { resamplingQuality ->
+            serverConfig.resamplingQuality?.let { resamplingQuality ->
                 log.debug("Setting resamplingQuality to {}", resamplingQuality)
                 it.resamplingQuality = resamplingQuality
             }

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -96,6 +96,11 @@ class AudioPlayerConfiguration {
             audioPlayerManager.setTrackStuckThreshold(trackStuckThresholdMs)
         }
 
+        serverConfig.useSeekGhosting?.let { seekGhosting ->
+            log.debug("Setting useSeekGhosting to {}", seekGhosting)
+            audioPlayerManager.setUseSeekGhosting(seekGhosting)
+        }
+
         val mcr: MediaContainerRegistry = MediaContainerRegistry.extended(*mediaContainerProbes.toTypedArray())
 
         if (sources.isYoutube) {

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -35,7 +35,7 @@ class ServerConfig {
     var bufferDurationMs: Int? = null
     var frameBufferDurationMs: Int? = null
     var opusEncodingQuality: Int? = null
-    var resamplingQuality: ResamplingQuality = ResamplingQuality.LOW
+    var resamplingQuality: ResamplingQuality? = null
     var trackStuckThresholdMs: Long? = null
     var youtubePlaylistLoadLimit: Int? = null
     var playerUpdateInterval: Int = 5

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -22,6 +22,7 @@
 
 package lavalink.server.config
 
+import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration.ResamplingQuality
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
@@ -33,6 +34,8 @@ class ServerConfig {
     var sentryDsn = ""
     var bufferDurationMs: Int? = null
     var frameBufferDurationMs: Int? = null
+    var opusEncodingQuality: Int? = null
+    var resamplingQuality: ResamplingQuality = ResamplingQuality.LOW
     var trackStuckThresholdMs: Long? = null
     var youtubePlaylistLoadLimit: Int? = null
     var playerUpdateInterval: Int = 5

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -37,6 +37,7 @@ class ServerConfig {
     var opusEncodingQuality: Int? = null
     var resamplingQuality: ResamplingQuality? = null
     var trackStuckThresholdMs: Long? = null
+    var useSeekGhosting: Boolean? = null
     var youtubePlaylistLoadLimit: Int? = null
     var playerUpdateInterval: Int = 5
     var isGcWarnings = true


### PR DESCRIPTION
Adds support for modifying the `opusEncodingQuality` and `resamplingQuality` fields found in `PlayerManager#getConfiguration`. The default values Lavaplayer uses when the configuration is unmodified are `10` and `LOW`, respectively, however these may not be to everyone's tastes hence the implementation of these settings.
