### PR TITLE
 Use zulu-openjdk 18 as base on Lavalink-Server's Dockerfile.

### DIFF
--- a/LavalinkServer/docker/Dockerfile
+++ b/LavalinkServer/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:13
+FROM azul/zulu-openjdk:18
 
 # Run as non-root user
 RUN groupadd -g 322 lavalink && \


### PR DESCRIPTION
Java 13 is quite old by now. Zulu's OpenJDK should work just fine on latest, in contrast to Adoptium which breaks Lavalink above Java 13 (they don't do TCK compilance tests...), which is what made the "doesn't work on anything above 13" statement widespread, as Adoptium is the default in Debian and Ubuntu.

I'd recommend testing before merging, even if this works for me.