### PR TITLE
Update application.yml.example

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -52,10 +52,13 @@ sentry:
 
 logging:
   file:
-    max-history: 30
-    max-size: 1GB
-  path: ./logs/
+    path: ./logs/
 
   level:
     root: INFO
     lavalink: INFO
+
+  logback:
+    rollingpolicy:
+      max-file-size: 1GB
+      max-history: 30


### PR DESCRIPTION
I had issues with the spring.log not being written when using an older application.yml with Lavalink 3.5-rc3. After asking about the format I was using, @davidffa let me know that the spring boot update in https://github.com/freyacodes/Lavalink/pull/641 changed the formatting of the logs section and the file rotation.