### PR TITLE
Add LavaClient to the list of libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Client | Platform | Compatible With | Additional Information
 -------|----------|-----------------|-----------------------
 [Lavalink-Client](https://github.com/freyacodes/lavalink-client) | Java | JDA/**Any** 
 [Lavalink.kt](https://github.com/DRSchlaubi/lavalink.kt) | Kotlin | JDA/Kord/**Any** | Kotlin Coroutines
+[LavaClient](https://github.com/HoneycombsTeam/LavaClient) | Java | JDA
 [Lavalink.py](https://github.com/Devoxin/Lavalink.py) | Python | **Any**
 [lavasnek_rs](https://github.com/vicky5124/lavasnek_rs) | Python | **Any\*** | *`asyncio`-based libraries only
 [lavaplayer-py](https://github.com/HazemMeqdad/lavaplayer) | Python | **Any\*** | *`asyncio`-based libraries only


### PR DESCRIPTION
Added my library ([LavaClient](https://github.com/HoneycombsTeam/LavaClient)) to the list of available Lavalink's libraries (aka. implementations).