### PR TITLE
release v3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+## 3.6.2
+* update lavaplayer to `1.3.99.1`. For more info see [here](https://github.com/freyacodes/Lavalink/pull/773)
+
 ## 3.6.1
-* update lavaplayer to `1.3.99`. For me info see [here](https://github.com/freyacodes/Lavalink/pull/768)
+* update lavaplayer to `1.3.99`. For more info see [here](https://github.com/freyacodes/Lavalink/pull/768)
 
 ## 3.6.0
 * new userId & clientName getters in the plugin-api. For more info see [here](https://github.com/freyacodes/Lavalink/pull/743).

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ fun VersionCatalogBuilder.spring() {
 }
 
 fun VersionCatalogBuilder.voice() {
-    version("lavaplayer", "1.3.99")
+    version("lavaplayer", "1.3.99.1")
 
     library("lavaplayer",            "com.github.walkyst.lavaplayer-fork", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "com.github.walkyst.lavaplayer-fork", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")


### PR DESCRIPTION
* update lavaplayer to `1.3.99.1`. For more info see [here](https://github.com/freyacodes/Lavalink/pull/773)