### PR TITLE
v3.7.1 release

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
@@ -122,22 +122,6 @@ object Launcher {
             return
         }
 
-        val config = File("./application.yml")
-        if (!config.exists()) {
-            log.info("No application.yml found, creating one...")
-            Launcher::class.java.getResource("/application.yml.example")?.let {
-                it.openStream().use {
-                    if (!config.createNewFile()) {
-                        log.error("Unable to create application.yml")
-                        return
-                    }
-                    config.outputStream().use { out ->
-                        it.copyTo(out)
-                    }
-                }
-            } ?: log.error("Unable to find application.yml.example in resources")
-        }
-
         val parent = launchPluginBootstrap()
         log.info("You can safely ignore the big red warning about illegal reflection. See https://github.com/freyacodes/Lavalink/issues/295")
         launchMain(parent, args)


### PR DESCRIPTION
revert autocreate of application.yml because the config file can have a lot of different names, we need a better mechanism to do this