### PR TITLE
Adding the custom version of Erela.js!

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Additional labels for release candidates are available as extensions to the `MAJ
 | [Lavacord](https://github.com/lavacord/lavacord)                                                      | Node.js  | **Any**                 | ❌                |                                 |
 | [FastLink](https://github.com/ThePedroo/FastLink)                                                     | Node.js  | **Any**                 | ❌                |                                 |
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)                                              | Node.js  | **Any**                 | ❌                |
-| [@skyra/audio](https://github.com/skyra-project/audio)                                                | Node.js  | discord.js              | ❌                |Archived                        |
+| [@skyra/audio](https://github.com/skyra-project/audio)                                                | Node.js  | discord.js              | ❌                | Archived                        |
 | [Poru](https://github.com/parasop/poru)                                                               | Node.js  | **Any**                 | ❌                |                                 |
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                                                         | Node.js  | **Any**                 | ✅                |                                 |                                |
-| [Erela.js-Custom](https://github.com/Tomato6966/erela.js)                                             | Node.js  | **Any**                 | ✅                |                                 |                                |
+| [Erela.js/Custom](https://github.com/Tomato6966/erela.js)                                             | Node.js  | **Any**                 | ✅                |                                 |                                |
 | [Lavaudio](https://github.com/rilysh/lavaudio)                                                        | Node.js  | **Any**                 | ❌                |
 | [Gorilink](https://github.com/Gorillas-Team/Gorilink)                                                 | Node.js  | discord.js              | ❌                | Archived/Unmaintained           |
 | [SandySounds](https://github.com/MrJohnCoder/SandySounds)                                             | Node.js  | **Any**                 | ❌                | Unmaintained                    |

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ Additional labels for release candidates are available as extensions to the `MAJ
 | [Lavacord](https://github.com/lavacord/lavacord)                                                      | Node.js  | **Any**                 | ❌                |                                 |
 | [FastLink](https://github.com/ThePedroo/FastLink)                                                     | Node.js  | **Any**                 | ❌                |                                 |
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)                                              | Node.js  | **Any**                 | ❌                |
-| [@skyra/audio](https://github.com/skyra-project/audio)                                                | Node.js  | discord.js              | ❌                | Archived                        |
+| [@skyra/audio](https://github.com/skyra-project/audio)                                                | Node.js  | discord.js              | ❌                |Archived                        |
 | [Poru](https://github.com/parasop/poru)                                                               | Node.js  | **Any**                 | ❌                |                                 |
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                                                         | Node.js  | **Any**                 | ✅                |                                 |                                |
+| [Erela.js-Custom](https://github.com/Tomato6966/erela.js)                                             | Node.js  | **Any**                 | ✅                |                                 |                                |
 | [Lavaudio](https://github.com/rilysh/lavaudio)                                                        | Node.js  | **Any**                 | ❌                |
 | [Gorilink](https://github.com/Gorillas-Team/Gorilink)                                                 | Node.js  | discord.js              | ❌                | Archived/Unmaintained           |
 | [SandySounds](https://github.com/MrJohnCoder/SandySounds)                                             | Node.js  | **Any**                 | ❌                | Unmaintained                    |


### PR DESCRIPTION
I have implemented a custom version of Erela.js created by Tomato6966. It supports both the REST API and WebSocket, even for users using an older version of Lavalink. The custom version of Erela.js supports both v3 and v4 of the REST API, allowing users to choose which version they prefer, and even v2 if necessary.