### PR TITLE
docs(impl): note that frameStats is missing not nullable

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -227,7 +227,7 @@ A collection of stats sent every minute.
 | uptime         | int                                 | The uptime of the node in milliseconds                                                           |
 | memory         | [Memory](#memory) object            | The memory stats of the node                                                                     |
 | cpu            | [CPU](#cpu) object                  | The cpu stats of the node                                                                        |
-| frameStats     | ?[Frame Stats](#frame-stats) object | The frame stats of the node. `null` if the node has no players or when retrieved via `/v3/stats` |
+| frameStats?    | [Frame Stats](#frame-stats) object  | The frame stats of the node. `null` if the node has no players or when retrieved via `/v3/stats` |
 
 ##### Memory
 
@@ -1368,7 +1368,7 @@ GET /v3/stats
 
 Response:
 
-`frameStats` is always `null` for this endpoint.
+`frameStats` is always missing for this endpoint.
 [Stats Object](#stats-object)
 
 <details>
@@ -1389,8 +1389,7 @@ Response:
     "cores": 4,
     "systemLoad": 0.5,
     "lavalinkLoad": 0.5
-  },
-  "frameStats": null
+  }
 }
 ```
 


### PR DESCRIPTION
`test_bot-bot-1       | future: <Task finished name='Task-185' coro=<Node._handle_msg() done, defined at /bot/mafic/node.py:578> exception=KeyError('frameStats')>`
```py
self.frame_stats: FrameStats | None = (
    FrameStats(data["frameStats"]) if data["frameStats"] is not None else None
)
```
`frameStats` is actually "ommitable" instead of "nullable"
This is already represented in `lavalink.protocol.v3.stats.Stats`.
