### PR TITLE
Update Pomice entry to reflect new changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Additional labels for release candidates are available as extensions to the `MAJ
 | [lavasnek_rs](https://github.com/vicky5124/lavasnek_rs)                                               | Python   | **Any\***               | ❌                | *`asyncio`-based libraries only |
 | [lavaplayer-py](https://github.com/HazemMeqdad/lavaplayer)                                            | Python   | **Any\***               | ❌                | *`asyncio`-based libraries only |
 | [Wavelink](https://github.com/PythonistaGuild/Wavelink)                                               | Python   | discord.py **V2**       | ❌                |                                 |
-| [Pomice](https://github.com/cloudwithax/pomice)                                                       | Python   | discord.py **V2**       | ❌                |                                 |
+| [Pomice](https://github.com/cloudwithax/pomice)                                                       | Python   | discord.py **V2**       | ✅                |                                 |
 | [discord-ext-lava](https://github.com/Axelware/discord-ext-lava)                                      | Python   | discord.py              | ❌                |                                 |
 | [Lavapy](https://github.com/Aspect1103/Lavapy)                                                        | Python   | discord.py              | ❌                |                                 |
 | [Magma](https://github.com/initzx/magma)                                                              | Python   | discord.py              | ❌                |                                 |


### PR DESCRIPTION
Library now includes REST support for new Lavalink API.