### PR TITLE
fix multiple resumes

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
@@ -205,6 +205,7 @@ class SocketContext(
 
     fun resume(session: WebSocketSession) {
         sessionPaused = false
+        session.attributes["sessionId"] = sessionId
         this.session = session
         log.info("Replaying ${resumeEventQueue.size} events")
 

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
@@ -205,8 +205,8 @@ class SocketContext(
 
     fun resume(session: WebSocketSession) {
         sessionPaused = false
-        session.attributes["sessionId"] = sessionId
         this.session = session
+        sendMessage(Message.ReadyEvent(true, sessionId))
         log.info("Replaying ${resumeEventQueue.size} events")
 
         // Bulk actions are not guaranteed to be atomic, so we need to do this imperatively

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -103,11 +103,11 @@ class SocketServer(
         if (resumeKey != null) resumable = resumableSessions.remove(resumeKey)
 
         if (resumable != null) {
+            session.attributes["sessionId"] = resumable.sessionId
             contextMap[resumable.sessionId] = resumable
             resumable.resume(session)
             log.info("Resumed session with key $resumeKey")
             resumable.eventEmitter.onWebSocketOpen(true)
-            resumable.sendMessage(Message.ReadyEvent(true, resumable.sessionId))
             return
         }
 
@@ -130,9 +130,8 @@ class SocketServer(
             objectMapper
         )
         contextMap[sessionId] = socketContext
-        socketContext.eventEmitter.onWebSocketOpen(false)
         socketContext.sendMessage(Message.ReadyEvent(false, sessionId))
-
+        socketContext.eventEmitter.onWebSocketOpen(false)
         if (clientName != null) {
             log.info("Connection successfully established from $clientName")
             return


### PR DESCRIPTION
when disconnecting after doing a resume once the `sessionId` is unset on the `WebsocketSession`

```
2023-02-12 01:15:56.015  WARN 1 --- [  XNIO-1 I/O-11] w.s.h.ExceptionWebSocketHandlerDecorator : Unhandled exception after connection closed for ExceptionWebSocketHandlerDecorator [delegate=LoggingWebSocketHandlerDecorator [delegate=lavalink.server.io.SocketServer@50d68830]]

java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "<parameter1>" is null
        at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(Unknown Source) ~[na:na]
        at java.base/java.util.concurrent.ConcurrentHashMap.remove(Unknown Source) ~[na:na]
        at lavalink.server.io.SocketServer.afterConnectionClosed(SocketServer.kt:161) ~[classes!/:na]
        at org.springframework.web.socket.handler.WebSocketHandlerDecorator.afterConnectionClosed(WebSocketHandlerDecorator.java:85) ~[spring-websocket-5.3.17.jar!/:5.3.17]
        at org.springframework.web.socket.handler.LoggingWebSocketHandlerDecorator.afterConnectionClosed(LoggingWebSocketHandlerDecorator.java:72) ~[spring-websocket-5.3.17.jar!/:5.3.17]
        at org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator.afterConnectionClosed(ExceptionWebSocketHandlerDecorator.java:78) ~[spring-websocket-5.3.17.jar!/:5.3.17]
        at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter.onClose(StandardWebSocketHandlerAdapter.java:145) ~[spring-websocket-5.3.17.jar!/:5.3.17]
        at io.undertow.websockets.jsr.UndertowSession.closeInternal(UndertowSession.java:235) ~[undertow-websockets-jsr-2.2.16.Final.jar!/:2.2.16.Final]
        at io.undertow.websockets.jsr.UndertowSession$3$1.run(UndertowSession.java:401) ~[undertow-websockets-jsr-2.2.16.Final.jar!/:2.2.16.Final]
        at org.xnio.nio.WorkerThread.safeRun(WorkerThread.java:612) ~[xnio-nio-3.8.6.Final.jar!/:3.8.6.Final]
        at org.xnio.nio.WorkerThread.run(WorkerThread.java:479) ~[xnio-nio-3.8.6.Final.jar!/:3.8.6.Final]
```