### PR TITLE
release v3.7.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,13 @@ on:
   workflow_call:
     secrets:
       DOCKER_USERNAME:
+        required: false
       DOCKER_TOKEN:
+        required: false
       DOCKER_REGISTRY:
+        required: false
       DOCKER_IMAGE:
+        required: false
 
 jobs:
   build:
@@ -43,24 +47,32 @@ jobs:
           path: LavalinkServer/build/libs/Lavalink.jar
 
       - name: Docker Meta
-        if: env.DOCKER_USERNAME && env.DOCKER_TOKEN && env.DOCKER_REGISTRY && env.DOCKER_IMAGE
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_IMAGE }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ env.DOCKER_IMAGE }}
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
             type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=sha,prefix=
 
       - name: Set up QEMU
-        if: env.DOCKER_USERNAME && env.DOCKER_TOKEN && env.DOCKER_REGISTRY && env.DOCKER_IMAGE
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        if: env.DOCKER_USERNAME && env.DOCKER_TOKEN && env.DOCKER_REGISTRY && env.DOCKER_IMAGE
         uses: docker/setup-buildx-action@v2
+        
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to docker registry
         if: env.DOCKER_USERNAME && env.DOCKER_TOKEN && env.DOCKER_REGISTRY && env.DOCKER_IMAGE
@@ -71,7 +83,6 @@ jobs:
           password: ${{ env.DOCKER_TOKEN }}
 
       - name: Build and Push
-        if: env.DOCKER_USERNAME && env.DOCKER_TOKEN && env.DOCKER_REGISTRY && env.DOCKER_IMAGE
         uses: docker/build-push-action@v3
         with:
           file: LavalinkServer/docker/Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+## 3.7.5
+* Fix `endTime` in `Player Update` endpoint only applying when playing a new track
+* Fix errors when doing multiple session resumes
+* Update lavaplayer to `1.4.0` see [here](https://github.com/Walkyst/lavaplayer-fork/releases/tag/1.4.0) for more info
+
+> **Note**
+> Lavalink Docker images are now found in the GitHub Container Registry instead of DockerHub
+
 ## 3.7.4
 * Fix an issue where Lavalink would not destroy a session when a client disconnects
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -694,7 +694,7 @@ Request:
 | encodedTrack? * | ?string                            | The encoded track base64 to play. `null` stops the current track              |
 | identifier? *   | string                             | The track identifier to play                                                  |
 | position?       | int                                | The track position in milliseconds                                            |
-| endTime?        | int                                | The track end time in milliseconds                                            |
+| endTime?        | ?int                               | The track end time in milliseconds (must be > 0)                              |
 | volume?         | int                                | The player volume from 0 to 1000                                              |
 | paused?         | bool                               | Whether the player is paused                                                  |
 | filters?        | [Filters](#filters) object         | The new filters to apply. This will override all previously applied filters   |                   

--- a/LavalinkServer/build.gradle.kts
+++ b/LavalinkServer/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.ajoberstar.grgit.Grgit
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.tasks.run.BootRun
@@ -16,7 +15,6 @@ apply(plugin = "kotlin")
 apply(plugin = "kotlin-spring")
 
 description = "Play audio to discord voice channels"
-version = versionFromTag()
 
 application {
     mainClass.set("lavalink.server.Launcher")
@@ -123,16 +121,37 @@ tasks {
     }
 }
 
-@SuppressWarnings("GrMethodMayBeStatic")
-fun versionFromTag(): String = Grgit.open(mapOf("currentDir" to project.rootDir)).use { git ->
-    val headTag = git.tag
-        .list()
-        .find { it.commit.id == git.head().id }
+publishing {
+    publications {
+        create<MavenPublication>("LavalinkServer") {
+            from(project.components["java"])
 
-    val clean = git.status().isClean || System.getenv("CI") != null
-    if (!clean) {
-        println("Git state is dirty, setting version as snapshot.")
+            pom {
+                name.set("Lavalink Server")
+                description.set("Lavalink Server")
+                url.set("https://github.com/freyacodes/lavalink")
+
+                licenses {
+                    license {
+                        name.set("The MIT License")
+                        url.set("https://github.com/freyacodes/Lavalink/blob/master/LICENSE")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("freyacodes")
+                        name.set("Freya Arbjerg")
+                        url.set("https://www.arbjerg.dev")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:ssh://github.com/freyacodes/lavalink.git")
+                    developerConnection.set("scm:git:ssh://github.com/freyacodes/lavalink.git")
+                    url.set("https://github.com/freyacodes/lavalink")
+                }
+            }
+        }
     }
-
-    return if (headTag != null && clean) headTag.name else "${git.head().id}-SNAPSHOT"
 }

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketContext.kt
@@ -206,6 +206,7 @@ class SocketContext(
     fun resume(session: WebSocketSession) {
         sessionPaused = false
         this.session = session
+        sendMessage(Message.ReadyEvent(true, sessionId))
         log.info("Replaying ${resumeEventQueue.size} events")
 
         // Bulk actions are not guaranteed to be atomic, so we need to do this imperatively

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -103,11 +103,11 @@ class SocketServer(
         if (resumeKey != null) resumable = resumableSessions.remove(resumeKey)
 
         if (resumable != null) {
+            session.attributes["sessionId"] = resumable.sessionId
             contextMap[resumable.sessionId] = resumable
             resumable.resume(session)
             log.info("Resumed session with key $resumeKey")
             resumable.eventEmitter.onWebSocketOpen(true)
-            resumable.sendMessage(Message.ReadyEvent(true, resumable.sessionId))
             return
         }
 
@@ -130,9 +130,8 @@ class SocketServer(
             objectMapper
         )
         contextMap[sessionId] = socketContext
-        socketContext.eventEmitter.onWebSocketOpen(false)
         socketContext.sendMessage(Message.ReadyEvent(false, sessionId))
-
+        socketContext.eventEmitter.onWebSocketOpen(false)
         if (clientName != null) {
             log.info("Connection successfully established from $clientName")
             return

--- a/README.md
+++ b/README.md
@@ -110,6 +110,4 @@ Put an `application.yml` file in your working directory. ([Example here](https:/
 
 Run with `java -jar Lavalink.jar`
 
-Docker images are available on the [Docker Hub](https://hub.docker.com/r/fredboat/lavalink/).
-
-[![Docker Pulls](https://img.shields.io/docker/pulls/fredboat/lavalink.svg)](https://hub.docker.com/r/fredboat/lavalink/)
+Docker images can be found under [packages](https://github.com/freyacodes/Lavalink/pkgs/container/lavalink) with old builds prior to `v3.7.4` being available on [Docker Hub](https://hub.docker.com/r/fredboat/lavalink/).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.ajoberstar.grgit.Grgit
 
 buildscript {
     repositories {
@@ -21,6 +22,7 @@ buildscript {
 
 allprojects {
     group = "lavalink"
+    version = versionFromTag()
 
     repositories {
         mavenCentral() // main maven repo
@@ -49,4 +51,18 @@ subprojects {
         options.compilerArgs.add("-Xlint:unchecked")
         options.compilerArgs.add("-Xlint:deprecation")
     }
+}
+
+@SuppressWarnings("GrMethodMayBeStatic")
+fun versionFromTag(): String = Grgit.open(mapOf("currentDir" to project.rootDir)).use { git ->
+    val headTag = git.tag
+        .list()
+        .find { it.commit.id == git.head().id }
+
+    val clean = git.status().isClean || System.getenv("CI") != null
+    if (!clean) {
+        println("Git state is dirty, setting version as snapshot.")
+    }
+
+    return if (headTag != null && clean) headTag.name else "${git.head().id}-SNAPSHOT"
 }

--- a/plugin-api/build.gradle.kts
+++ b/plugin-api/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 val archivesBaseName = "plugin-api"
 group = "dev.arbjerg.lavalink"
-version = "3.6.1"
 
 dependencies {
     api(libs.spring.boot)

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    signing
     `java-library`
     `maven-publish`
     kotlin("jvm")
@@ -7,7 +8,6 @@ plugins {
 
 val archivesBaseName = "protocol"
 group = "dev.arbjerg.lavalink"
-version = "3.7.0"
 
 java {
     targetCompatibility = JavaVersion.VERSION_11
@@ -22,6 +22,8 @@ dependencies {
     implementation(libs.kotlin.stdlib.jdk8)
     implementation(libs.jackson.module.kotlin)
 }
+
+val isGpgKeyDefined = findProperty("signing.gnupg.keyName") != null
 
 publishing {
     publications {
@@ -55,5 +57,27 @@ publishing {
                 }
             }
         }
+    }
+    if (isGpgKeyDefined) {
+        repositories {
+            val snapshots = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            val releases = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+            maven(if ((version as String).endsWith("SNAPSHOT")) snapshots else releases) {
+                credentials {
+                    password = findProperty("ossrhPassword") as? String
+                    username = findProperty("ossrhUsername") as? String
+                }
+            }
+        }
+    } else {
+        println("Not capable of publishing to OSSRH because of missing GPG key")
+    }
+}
+
+if (isGpgKeyDefined) {
+    signing {
+        sign(publishing.publications["Protocol"])
+        useGpgCmd()
     }
 }

--- a/protocol/src/main/java/dev/arbjerg/lavalink/protocol/v3/player.kt
+++ b/protocol/src/main/java/dev/arbjerg/lavalink/protocol/v3/player.kt
@@ -67,7 +67,7 @@ data class PlayerUpdate(
     val encodedTrack: Omissible<String?> = Omissible.omitted(),
     val identifier: Omissible<String> = Omissible.omitted(),
     val position: Omissible<Long> = Omissible.omitted(),
-    val endTime: Omissible<Long> = Omissible.omitted(),
+    val endTime: Omissible<Long?> = Omissible.omitted(),
     val volume: Omissible<Int> = Omissible.omitted(),
     val paused: Omissible<Boolean> = Omissible.omitted(),
     val filters: Omissible<Filters> = Omissible.omitted(),
@@ -91,7 +91,7 @@ class PlayerUpdateDeserializer : JsonDeserializer<PlayerUpdate>() {
         } ?: Omissible.omitted()
 
         val endTime = node.get("endTime")?.let {
-            Omissible.of(it.asLong())
+            if (it.isNull) Omissible.of<Long?>(null) else Omissible.of<Long?>(it.asLong())
         } ?: Omissible.omitted()
 
         val volume = node.get("volume")?.let {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,7 @@ fun VersionCatalogBuilder.spring() {
 }
 
 fun VersionCatalogBuilder.voice() {
-    version("lavaplayer", "1.3.99.2")
+    version("lavaplayer", "1.4.0")
 
     library("lavaplayer",            "com.github.walkyst.lavaplayer-fork", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "com.github.walkyst.lavaplayer-fork", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")


### PR DESCRIPTION
* Fix `endTime` in `Player Update` endpoint only applying when playing a new track
* Fix errors when doing multiple session resumes
* Update lavaplayer to `1.4.0` see [here](https://github.com/Walkyst/lavaplayer-fork/releases/tag/1.4.0) for more info

> **Note**
> Lavalink Docker images are now found in the GitHub Container Registry instead of DockerHub