### PR TITLE
Do not register Mixer/Beam source manager

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -156,7 +156,6 @@ class AudioPlayerConfiguration {
         if (sources.isBandcamp) audioPlayerManager.registerSourceManager(BandcampAudioSourceManager())
         if (sources.isTwitch) audioPlayerManager.registerSourceManager(TwitchStreamAudioSourceManager())
         if (sources.isVimeo) audioPlayerManager.registerSourceManager(VimeoAudioSourceManager())
-        if (sources.isMixer) audioPlayerManager.registerSourceManager(BeamAudioSourceManager())
         if (sources.isLocal) audioPlayerManager.registerSourceManager(LocalAudioSourceManager(mcr))
 
         audioSourceManagers.forEach {

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioSourcesConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioSourcesConfig.kt
@@ -14,7 +14,6 @@ data class AudioSourcesConfig(
     var isSoundcloud: Boolean = true,
     var isTwitch: Boolean = true,
     var isVimeo: Boolean = true,
-    var isMixer: Boolean = true,
     var isHttp: Boolean = true,
     var isLocal: Boolean = false,
 )


### PR DESCRIPTION
Mixer was shut down in 2020, making this source manager useless.