### PR TITLE
use lavadsp fork with darwin arm stuff fixed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ allprojects {
         mavenCentral() // main maven repo
         mavenLocal()   // useful for developing
         maven("https://m2.dv8tion.net/releases")
+        maven("https://maven.topi.wtf/releases")
         jcenter()
         maven("https://jitpack.io") // build projects directly from GitHub
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ fun VersionCatalogBuilder.voice() {
     library("lavaplayer",            "com.github.walkyst.lavaplayer-fork", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "com.github.walkyst.lavaplayer-fork", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")
 //    library("lavadsp",               "com.github.natanbc", "lavadsp").version("0.7.7")
-    library("lavadsp",               "com.github.topisenpai", "lavadsp").version("0.0.1")
+    library("lavadsp",               "com.github.topisenpai", "lavadsp").version("0.0.2")
 
     library("koe",          "moe.kyokobot.koe", "core").version("2.0.0-rc1")
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").version("2.0.0-rc1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ fun VersionCatalogBuilder.voice() {
     library("lavaplayer",            "com.github.walkyst.lavaplayer-fork", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "com.github.walkyst.lavaplayer-fork", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")
 //    library("lavadsp",               "com.github.natanbc", "lavadsp").version("0.7.7")
-    library("lavadsp",               "com.github.topisenpai", "lavadsp").version("0.0.2")
+    library("lavadsp",               "com.github.topisenpai", "lavadsp").version("0.0.1")
 
     library("koe",          "moe.kyokobot.koe", "core").version("2.0.0-rc1")
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").version("2.0.0-rc1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,8 @@ fun VersionCatalogBuilder.voice() {
 
     library("lavaplayer",            "com.github.walkyst.lavaplayer-fork", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "com.github.walkyst.lavaplayer-fork", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")
-    library("lavadsp",               "com.github.natanbc", "lavadsp").version("0.7.7")
+//    library("lavadsp",               "com.github.natanbc", "lavadsp").version("0.7.7")
+    library("lavadsp",               "com.github.topisenpai", "lavadsp").version("0.0.1")
 
     library("koe",          "moe.kyokobot.koe", "core").version("2.0.0-rc1")
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").version("2.0.0-rc1")


### PR DESCRIPTION
current lavadsp does not work on the new m1 macs. Since lavadsp is archived again I forked it &  monkey patched it to not use avx2 natives on m1 macs. This resolves the issue.

to note:
I removed freedsb support which isn't supported by lavaplayer anyway and therefore not needed

