### PR TITLE
implement full semver spec

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1303,7 +1303,7 @@ Parsed Semantic Versioning 2.0.0. See https://semver.org/ for more info
 | minor      | int     | The minor version of this Lavalink server                                          |
 | patch      | int     | The patch version of this Lavalink server                                          |
 | preRelease | ?string | The pre-release version according to semver as a `.` separated list of identifiers |
-| build      | ?string | The build version according to semver as a `.` separated list of identifiers       |
+| build      | ?string | The build metadata according to semver as a `.` separated list of identifiers      |
 
 ##### Git Object
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1296,14 +1296,14 @@ Response:
 
 Parsed Semantic Versioning 2.0.0. See https://semver.org/ for more info
 
-| Field         | Type    | Description                                                                           |
-|---------------|---------|---------------------------------------------------------------------------------------|
-| semver        | string  | The full version string of this Lavalink server                                       |
-| major         | int     | The major version of this Lavalink server                                             |
-| minor         | int     | The minor version of this Lavalink server                                             |
-| patch         | int     | The patch version of this Lavalink server                                             |
-| preRelease    | ?string | The pre-release version according to semver as a `.` separated list of identifiers    |
-| buildMetadata | ?string | The build-metadata version according to semver as a `.` separated list of identifiers |
+| Field      | Type    | Description                                                                        |
+|------------|---------|------------------------------------------------------------------------------------|
+| semver     | string  | The full version string of this Lavalink server                                    |
+| major      | int     | The major version of this Lavalink server                                          |
+| minor      | int     | The minor version of this Lavalink server                                          |
+| patch      | int     | The patch version of this Lavalink server                                          |
+| preRelease | ?string | The pre-release version according to semver as a `.` separated list of identifiers |
+| build      | ?string | The build version according to semver as a `.` separated list of identifiers       |
 
 ##### Git Object
 
@@ -1331,7 +1331,7 @@ Parsed Semantic Versioning 2.0.0. See https://semver.org/ for more info
     "minor": 7,
     "patch": 0,
     "preRelease": "rc.1",
-    "buildMetadata": "test"
+    "build": "test"
   },
   "buildTime": 1664223916812,
   "git": {
@@ -1347,9 +1347,9 @@ Parsed Semantic Versioning 2.0.0. See https://semver.org/ for more info
   ],
   "filters": [
     "equalizer",
-		"karaoke",
-		"timescale",
-		"channelMix"
+    "karaoke",
+    "timescale",
+    "channelMix"
   ],
   "plugins": [
     {

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1294,13 +1294,16 @@ Response:
 
 ##### Version Object
 
-| Field      | Type    | Description                                                                        |
-|------------|---------|------------------------------------------------------------------------------------|
-| semver     | string  | The full version string of this Lavalink server                                    |
-| major      | int     | The major version of this Lavalink server                                          |
-| minor      | int     | The minor version of this Lavalink server                                          |
-| patch      | int     | The patch version of this Lavalink server                                          |
-| preRelease | ?string | The pre-release version according to semver as a `.` separated list of identifiers |
+Parsed Semantic Versioning 2.0.0. See https://semver.org/ for more info
+
+| Field         | Type    | Description                                                                           |
+|---------------|---------|---------------------------------------------------------------------------------------|
+| semver        | string  | The full version string of this Lavalink server                                       |
+| major         | int     | The major version of this Lavalink server                                             |
+| minor         | int     | The minor version of this Lavalink server                                             |
+| patch         | int     | The patch version of this Lavalink server                                             |
+| preRelease    | ?string | The pre-release version according to semver as a `.` separated list of identifiers    |
+| buildMetadata | ?string | The build-metadata version according to semver as a `.` separated list of identifiers |
 
 ##### Git Object
 
@@ -1323,11 +1326,12 @@ Response:
 ```json
 {
   "version": {
-    "string": "3.7.0-rc.1",
+    "string": "3.7.0-rc.1+test",
     "major": 3,
     "minor": 7,
     "patch": 0,
-    "preRelease": "rc.1"
+    "preRelease": "rc.1",
+    "buildMetadata": "test"
   },
   "buildTime": 1664223916812,
   "git": {

--- a/README.md
+++ b/README.md
@@ -50,14 +50,13 @@ Please see [here](CHANGELOG.md)
 
 Lavalink follows [Semantic Versioning](https://semver.org/).
 
-Given a version number `MAJOR.MINOR.PATCH`, the following rules apply:
+Given a version number `MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA`, the following rules apply:
 
     MAJOR breaking API changes
     MINOR new backwards compatible features
     PATCH backwards compatible bug fixes
-
-Additional labels for release candidates are available as extensions to the `MAJOR.MINOR.PATCH-rcNUMBER`(`3.6.0-rc1`) format.
-
+    PRERELEASE pre-release version
+    BUILDMETADATA build metadata
 
 ## Client libraries:
 | Client                                                                                                | Platform | Compatible With                            | REST API Support | Additional Information          |

--- a/README.md
+++ b/README.md
@@ -50,13 +50,22 @@ Please see [here](CHANGELOG.md)
 
 Lavalink follows [Semantic Versioning](https://semver.org/).
 
-Given a version number `MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA`, the following rules apply:
+The version number is composed of the following parts:
 
     MAJOR breaking API changes
     MINOR new backwards compatible features
     PATCH backwards compatible bug fixes
     PRERELEASE pre-release version
-    BUILDMETADATA build metadata
+    BUILD additional build metadata
+
+Version numbers can come in different combinations, depending on the release type:
+
+    `MAJOR.MINOR.PATCH` - Stable release
+    `MAJOR.MINOR.PATCH+BUILDMETADATA` - Stable release with build metadata
+    `MAJOR.MINOR.PATCH-PRERELEASE` - Pre-release
+    `MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA` - Pre-release with build metadata
+
+---
 
 ## Client libraries:
 | Client                                                                                                | Platform | Compatible With                            | REST API Support | Additional Information          |

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ The version number is composed of the following parts:
 Version numbers can come in different combinations, depending on the release type:
 
     `MAJOR.MINOR.PATCH` - Stable release
-    `MAJOR.MINOR.PATCH+BUILDMETADATA` - Stable release with build metadata
+    `MAJOR.MINOR.PATCH+BUILD` - Stable release with additional build metadata
     `MAJOR.MINOR.PATCH-PRERELEASE` - Pre-release
-    `MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA` - Pre-release with build metadata
+    `MAJOR.MINOR.PATCH-PRERELEASE+BUILD` - Pre-release additional build metadata
 
 ---
 

--- a/protocol/src/main/java/dev/arbjerg/lavalink/protocol/v3/info.kt
+++ b/protocol/src/main/java/dev/arbjerg/lavalink/protocol/v3/info.kt
@@ -19,19 +19,19 @@ data class Version(
     val minor: Int,
     val patch: Int,
     val preRelease: String?,
-    val buildMetadata: String?,
+    val build: String?,
 ) {
     companion object {
 
-        private val versionRegex = Regex("""^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$""")
+        private val versionRegex = Regex("""^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$""")
         fun fromSemver(semver: String): Version {
             val match = versionRegex.matchEntire(semver) ?: return Version(semver, 0, 0, 0, null, null)
             val major = match.groups["major"]!!.value.toInt()
             val minor = match.groups["minor"]!!.value.toInt()
             val patch = match.groups["patch"]!!.value.toInt()
             val preRelease = match.groups["prerelease"]?.value
-            val buildMetadata = match.groups["buildmetadata"]?.value
-            return Version(semver, major, minor, patch, preRelease, buildMetadata)
+            val build = match.groups["build"]?.value
+            return Version(semver, major, minor, patch, preRelease, build)
         }
     }
 }

--- a/protocol/src/main/java/dev/arbjerg/lavalink/protocol/v3/info.kt
+++ b/protocol/src/main/java/dev/arbjerg/lavalink/protocol/v3/info.kt
@@ -19,19 +19,19 @@ data class Version(
     val minor: Int,
     val patch: Int,
     val preRelease: String?,
+    val buildMetadata: String?,
 ) {
     companion object {
 
-        private val versionRegex =
-            Regex("""^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?""")
-
+        private val versionRegex = Regex("""^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$""")
         fun fromSemver(semver: String): Version {
-            val match = versionRegex.matchEntire(semver) ?: return Version(semver, 0, 0, 0, null)
+            val match = versionRegex.matchEntire(semver) ?: return Version(semver, 0, 0, 0, null, null)
             val major = match.groups["major"]!!.value.toInt()
             val minor = match.groups["minor"]!!.value.toInt()
             val patch = match.groups["patch"]!!.value.toInt()
             val preRelease = match.groups["prerelease"]?.value
-            return Version(semver, major, minor, patch, preRelease)
+            val buildMetadata = match.groups["buildmetadata"]?.value
+            return Version(semver, major, minor, patch, preRelease, buildMetadata)
         }
     }
 }


### PR DESCRIPTION
red folks want to add a special identifier to their lavalink builds.
This requires the full semver spec which includes `build metadata` (`+metadata`)

