### PR TITLE
use getDuration instead of info.length

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/util/util.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/util/util.kt
@@ -44,7 +44,7 @@ fun AudioTrack.toInfo(): TrackInfo {
         this.identifier,
         this.isSeekable,
         this.info.author,
-        this.info.length,
+        this.duration,
         this.info.isStream,
         this.position,
         this.info.title,


### PR DESCRIPTION
Currently lavalink returns the static track info length via it's API.

That length can be quite inaccurate depending on the source as they quite often use the `DelegatedAudioTrack` class. Once the track is being loaded it can return a more accurate `length`.
This is especially the case for Spotify & AppleMusic support in [LavaSrc](https://github.com/TopiSenpai/LavaSrc) as it searches for the same/similar tracks on other platforms which often have different track durations.

With this change, the `/loadtracks` endpoint would return the `length` from `Spotify`/`AppleMusic` and once it's being played the actual `length` from the underlaying source being used