### PR TITLE
update lavalink dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 13
+          java-version: 17
           cache: gradle
 
       - name: Setup Gradle

--- a/LavalinkServer/build.gradle.kts
+++ b/LavalinkServer/build.gradle.kts
@@ -23,8 +23,8 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     withJavadocJar()
     withSourcesJar()
 }
@@ -66,8 +66,6 @@ dependencies {
         // This version of SLF4J does not recognise Logback 1.2.3
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
-
-    compileOnly(libs.spotbugs)
 
     testImplementation(libs.spring.boot.test)
 }

--- a/LavalinkServer/build.gradle.kts
+++ b/LavalinkServer/build.gradle.kts
@@ -58,7 +58,10 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.logback)
     implementation(libs.sentry.logback)
-    implementation(libs.oshi)
+    implementation(libs.oshi) {
+        // This version of SLF4J does not recognise Logback 1.2.3
+        exclude(group = "org.slf4j", module = "slf4j-api")
+    }
     implementation(libs.json)
 
     compileOnly(libs.spotbugs)

--- a/LavalinkServer/build.gradle.kts
+++ b/LavalinkServer/build.gradle.kts
@@ -5,14 +5,13 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 plugins {
     application
     `maven-publish`
+    id("org.springframework.boot")
+    id("com.gorylenko.gradle-git-properties")
+    id("org.ajoberstar.grgit")
+    id("com.adarshr.test-logger")
+    id("kotlin")
+    id("kotlin-spring")
 }
-
-apply(plugin = "org.springframework.boot")
-apply(plugin = "com.gorylenko.gradle-git-properties")
-apply(plugin = "org.ajoberstar.grgit")
-apply(plugin = "com.adarshr.test-logger")
-apply(plugin = "kotlin")
-apply(plugin = "kotlin-spring")
 
 val archivesBaseName = "Lavalink-Server"
 description = "Play audio to discord voice channels"

--- a/LavalinkServer/src/main/java/lavalink/server/config/RequestAuthorizationFilter.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/RequestAuthorizationFilter.kt
@@ -1,13 +1,13 @@
 package lavalink.server.config
 
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.web.servlet.HandlerInterceptor
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 @Configuration
 class RequestAuthorizationFilter(

--- a/LavalinkServer/src/main/java/lavalink/server/io/RequestLoggingFilter.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/RequestLoggingFilter.kt
@@ -1,9 +1,9 @@
 package lavalink.server.io
 
+import jakarta.servlet.http.HttpServletRequest
 import lavalink.server.config.RequestLoggingConfig
 import org.slf4j.LoggerFactory
 import org.springframework.web.filter.AbstractRequestLoggingFilter
-import javax.servlet.http.HttpServletRequest
 
 class RequestLoggingFilter(
     requestLoggingConfig: RequestLoggingConfig

--- a/LavalinkServer/src/main/java/lavalink/server/io/ResponseHeaderFilter.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/ResponseHeaderFilter.kt
@@ -1,10 +1,10 @@
 package lavalink.server.io
 
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
-import javax.servlet.FilterChain
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 @Component
 class ResponseHeaderFilter : OncePerRequestFilter() {

--- a/LavalinkServer/src/main/java/lavalink/server/io/RoutePlannerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/RoutePlannerRestHandler.kt
@@ -3,6 +3,7 @@ package lavalink.server.io
 import com.sedmelluq.lava.extensions.youtuberotator.planner.*
 import dev.arbjerg.lavalink.protocol.v4.RoutePlannerFreeAddress
 import dev.arbjerg.lavalink.protocol.v4.RoutePlannerStatus
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -13,7 +14,6 @@ import org.springframework.web.server.ResponseStatusException
 import java.net.InetAddress
 import java.net.UnknownHostException
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 class RoutePlannerRestHandler(private val routePlanner: AbstractRoutePlanner?) {

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/PrometheusMetricsController.java
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/PrometheusMetricsController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -36,12 +35,12 @@ public class PrometheusMetricsController {
     }
 
     @GetMapping(produces = TextFormat.CONTENT_TYPE_004)
-    public ResponseEntity<String> getMetrics(@Nullable @RequestParam(name = "name[]", required = false) String[] includedParam)
+    public ResponseEntity<String> getMetrics(@RequestParam(name = "name[]", required = false) String[] includedParam)
             throws IOException {
         return buildAnswer(includedParam);
     }
 
-    private ResponseEntity<String> buildAnswer(@Nullable String[] includedParam) throws IOException {
+    private ResponseEntity<String> buildAnswer(String[] includedParam) throws IOException {
         Set<String> params;
         if (includedParam == null) {
             params = Collections.emptySet();
@@ -50,11 +49,9 @@ public class PrometheusMetricsController {
         }
 
         Writer writer = new StringWriter();
-        try {
+        try (writer) {
             TextFormat.write004(writer, this.registry.filteredMetricFamilySamples(params));
             writer.flush();
-        } finally {
-            writer.close();
         }
 
         return new ResponseEntity<>(writer.toString(), HttpStatus.OK);

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
@@ -27,6 +27,7 @@ import dev.arbjerg.lavalink.protocol.v4.EncodedTracks
 import dev.arbjerg.lavalink.protocol.v4.LoadResult
 import dev.arbjerg.lavalink.protocol.v4.Track
 import dev.arbjerg.lavalink.protocol.v4.Tracks
+import jakarta.servlet.http.HttpServletRequest
 import lavalink.server.util.decodeTrack
 import lavalink.server.util.toTrack
 import org.slf4j.LoggerFactory
@@ -35,7 +36,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.util.concurrent.CompletionStage
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 class AudioLoaderRestHandler(

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A [basic example bot](Testbot) is available.
 
 ## Requirements
 
-* Java 11 LTS or newer required. (we recommend running the latest LTS version or newer)
+* Java 17 LTS or newer required. (we recommend running the latest LTS version or newer)
 * OpenJDK or Zulu running on Linux AMD64 is officially supported.
 
 Support for Darwin (Mac), Windows AMD64, and Linux ARM (Raspberry Pi) is provided on a best-effort basis. This is dependent on Lavaplayer's native libraries.
@@ -57,8 +57,6 @@ JDA-NAS(Native Audio Buffer) & the Timescale filter are currently not supported 
 
 
 Support for other JVMs is also best-effort. Periodic CPU utilization stats are prone not to work everywhere.
-
-**\*Java 11 appears to have some issues with Discord's TLS 1.3. Java 14 has other undiagnosed HTTPS problems. Use Java 13. Docker images have been updated.** See [#258](https://github.com/lavalink-devs/Lavalink/issues/258), [#260](https://github.com/lavalink-devs/Lavalink/issues/260)
 
 ## Changelog
 

--- a/Testbot/build.gradle.kts
+++ b/Testbot/build.gradle.kts
@@ -7,11 +7,6 @@ plugins {
 group = "dev.arbjerg.lavalink"
 version = "1.0"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
 application {
     mainClass.set("lavalink.testbot.TestbotKt")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,23 +1,16 @@
 import org.ajoberstar.grgit.Grgit
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-    repositories {
-        mavenLocal()
-        maven("https://plugins.gradle.org/m2/")
-        maven("https://repo.spring.io/plugins-release")
-        maven("https://jitpack.io")
-        maven("https://m2.dv8tion.net/releases")
-    }
-
-    dependencies {
-        classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1 ")
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:3.1.0")
-        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.2.0.3129")
-        classpath("com.adarshr:gradle-test-logger-plugin:3.2.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
-        classpath("org.jetbrains.kotlin:kotlin-allopen:1.8.22")
-    }
+plugins {
+    id("org.jetbrains.dokka") version "1.8.20" apply false
+    id("com.gorylenko.gradle-git-properties") version "2.4.1"
+    id("org.ajoberstar.grgit") version "5.2.0"
+    id("org.springframework.boot") version "3.1.0" apply false
+    id("org.sonarqube") version "4.2.0.3129"
+    id("com.adarshr.test-logger") version "3.2.0"
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"
+    id("org.jetbrains.kotlin.plugin.allopen") version "1.8.22"
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.8.22" apply false
 }
 
 allprojects {
@@ -31,10 +24,6 @@ allprojects {
         jcenter()
         maven("https://jitpack.io") // build projects directly from GitHub
     }
-}
-
-plugins {
-    id("org.jetbrains.dokka") version "1.8.20"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,12 +11,12 @@ buildscript {
     }
 
     dependencies {
-        classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.2")
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.6.6")
-        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.2")
-        classpath("com.adarshr:gradle-test-logger-plugin:1.6.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")
-        classpath("org.jetbrains.kotlin:kotlin-allopen:1.8.21")
+        classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1 ")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:3.1.0")
+        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.2.0.3129")
+        classpath("com.adarshr:gradle-test-logger-plugin:3.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+        classpath("org.jetbrains.kotlin:kotlin-allopen:1.8.22")
     }
 }
 
@@ -34,7 +34,7 @@ allprojects {
 }
 
 plugins {
-    id("org.jetbrains.dokka") version "1.8.10"
+    id("org.jetbrains.dokka") version "1.8.20"
 }
 
 subprojects {
@@ -44,7 +44,7 @@ subprojects {
     }
 
     tasks.withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     tasks.withType<JavaCompile> {

--- a/plugin-api/build.gradle.kts
+++ b/plugin-api/build.gradle.kts
@@ -20,12 +20,12 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
         freeCompilerArgs.add("-Xjvm-default=all")
     }
 }

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `maven-publish`
     signing
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "1.8.21"
+    kotlin("plugin.serialization") version "1.8.22"
 }
 
 val archivesBaseName = "protocol"
@@ -16,7 +16,7 @@ kotlin {
     jvm {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
             }
         }
     }

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -3,10 +3,10 @@ import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 
 plugins {
-    `maven-publish`
     signing
+    `maven-publish`
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "1.8.22"
+    kotlin("plugin.serialization")
 }
 
 val archivesBaseName = "protocol"

--- a/protocol/src/commonTest/kotlin/OmissibleTest.kt
+++ b/protocol/src/commonTest/kotlin/OmissibleTest.kt
@@ -1,7 +1,6 @@
 import dev.arbjerg.lavalink.protocol.v4.Omissible
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.js.JsName

--- a/protocol/src/commonTest/kotlin/PlayerSerializerTest.kt
+++ b/protocol/src/commonTest/kotlin/PlayerSerializerTest.kt
@@ -1,7 +1,6 @@
 import dev.arbjerg.lavalink.protocol.v4.Omissible
 import dev.arbjerg.lavalink.protocol.v4.Player
 import dev.arbjerg.lavalink.protocol.v4.PlayerUpdate
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.js.JsName
 import kotlin.test.Test

--- a/protocol/src/commonTest/kotlin/Utils.kt
+++ b/protocol/src/commonTest/kotlin/Utils.kt
@@ -1,6 +1,5 @@
 import dev.arbjerg.lavalink.protocol.v4.Omissible
 import dev.arbjerg.lavalink.protocol.v4.json
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlin.test.assertEquals
 import kotlin.test.assertIs

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,7 +75,7 @@ fun VersionCatalogBuilder.common() {
 
     library("logback",        "ch.qos.logback",       "logback-classic").version("1.2.3")
     library("sentry-logback", "io.sentry",            "sentry-logback").version("1.7.2")
-    library("oshi",           "com.github.oshi",      "oshi-core").version("5.7.4")
+    library("oshi",           "com.github.oshi",      "oshi-core").version("6.4.3")
     library("json",           "org.json",             "json").version("20180813")
 
     library("spotbugs", "com.github.spotbugs", "spotbugs-annotations").version("3.1.6")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,9 +23,9 @@ dependencyResolutionManagement {
 }
 
 fun VersionCatalogBuilder.spring() {
-    version("spring-boot", "2.6.6")
+    version("spring-boot", "3.1.0")
 
-    library("spring-websocket", "org.springframework", "spring-websocket").version("5.3.17")
+    library("spring-websocket", "org.springframework", "spring-websocket").version("6.0.9")
 
     library("spring-boot",          "org.springframework.boot", "spring-boot").versionRef("spring-boot")
     library("spring-boot-web",      "org.springframework.boot", "spring-boot-starter-web").versionRef("spring-boot")
@@ -36,7 +36,7 @@ fun VersionCatalogBuilder.spring() {
 }
 
 fun VersionCatalogBuilder.voice() {
-    version("lavaplayer", "ef075855da")
+    version("lavaplayer", "17c75f5")
 
     library("lavaplayer",            "com.github.walkyst.lavaplayer-fork", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "com.github.walkyst.lavaplayer-fork", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")
@@ -55,7 +55,7 @@ fun VersionCatalogBuilder.voice() {
 }
 
 fun VersionCatalogBuilder.metrics() {
-    version("prometheus", "0.5.0")
+    version("prometheus", "0.16.0")
 
     library("metrics",         "io.prometheus", "simpleclient").versionRef("prometheus")
     library("metrics-hotspot", "io.prometheus", "simpleclient_hotspot").versionRef("prometheus")
@@ -66,19 +66,17 @@ fun VersionCatalogBuilder.metrics() {
 }
 
 fun VersionCatalogBuilder.common() {
-    version("kotlin", "1.7.20")
+    version("kotlin", "1.8.22")
 
     library("kotlin-reflect",     "org.jetbrains.kotlin", "kotlin-reflect").versionRef("kotlin")
     library("kotlin-stdlib-jdk8", "org.jetbrains.kotlin", "kotlin-stdlib-jdk8").versionRef("kotlin")
 
-    library("logback",        "ch.qos.logback",       "logback-classic").version("1.2.3")
-    library("sentry-logback", "io.sentry",            "sentry-logback").version("1.7.2")
-    library("oshi",           "com.github.oshi",      "oshi-core").version("6.4.3")
-
-    library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").version("1.5.0")
+    library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").version("1.5.1")
     library("kotlinx-datetime", "org.jetbrains.kotlinx", "kotlinx-datetime").version("0.4.0")
 
-    library("spotbugs", "com.github.spotbugs", "spotbugs-annotations").version("3.1.6")
+    library("logback",        "ch.qos.logback",       "logback-classic").version("1.4.7")
+    library("sentry-logback", "io.sentry",            "sentry-logback").version("6.22.0")
+    library("oshi",           "com.github.oshi",      "oshi-core").version("6.4.3")
 }
 
 fun VersionCatalogBuilder.other() {


### PR DESCRIPTION
this pr updates all lavalink dependencies to their latest versions.
due to spring boot 3.0 we need to bump the minimal java version to `17` from `11`.
this also already includes https://github.com/lavalink-devs/Lavalink/pull/892