### PR TITLE
Fixed URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [basic example bot](Testbot) is available.
 [![Lavalink Guild](https://discordapp.com/api/guilds/1082302532421943407/embed.png?style=banner2)](https://discord.gg/ZW4s47Ppw4)
 
 > [!Warning]
-> Lavalink v4 is now in beta! See [here](CHANGELOG.md#400-beta1) for more information.
+> Lavalink v4 is now in beta! See [here](https://github.com/lavalink-devs/lavalink/CHANGELOG.md#400-beta1) for more information.
 
 <details>
 <summary>Table of Contents</summary>


### PR DESCRIPTION
404 URL
(github.com/lavalink/CHANGELOG.md)
to proper URL