### PR TITLE
add lavalink client 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,19 +98,19 @@ Version numbers can come in different combinations, depending on the release typ
 ---
 
 ## Client libraries:
-| Client                                                           | Platform | Compatible With                            | Additional Information                 |
-|------------------------------------------------------------------|----------|--------------------------------------------|----------------------------------------|
-| [Lavalink.kt](https://github.com/DRSchlaubi/Lavalink.kt)         | Kotlin   | Kord/JDA/**Any**                           | Kotlin Coroutines                      |
-| [Coglink](https://github.com/PerformanC/Coglink)                 | C        | Concord                                    |                                        |
-| [DisGoLink](https://github.com/disgoorg/disgolink)               | Go       | **Any**                                    |                                        |
-| [Mafic](https://github.com/ooliver1/mafic)                       | Python   | discord.py **V2**/nextcord/disnake/py-cord |                                        |
-| [Lavacord](https://github.com/lavacord/Lavacord)                 | Node.js  | **Any**                                    |                                        |
-| [Lavalink-client](https://github.com/tomato6966/lavalink-client) | Node.js  | **Any Discord Wrapper** (TS, (c/m)JS, ESM) | v4-only, automated, custom queue-store |
-| [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)         | Node.js  | **Any**                                    |                                        |
-| [Magmastream](https://github.com/Blackfort-Hosting/magmastream)  | Node.js  | **Any**                                    |                                        |
-| [Shoukaku](https://github.com/Deivu/Shoukaku)                    | Node.js  | **Any**                                    |                                        |
-| [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)          | Rust     | **Any**                                    | `tokio`-based                          |
-| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)    | .NET     | DisCatSharp                                | v10.4.2+                               |
+| Client                                                           | Platform | Compatible With                            | Additional Information |
+|------------------------------------------------------------------|----------|--------------------------------------------|------------------------|
+| [Lavalink.kt](https://github.com/DRSchlaubi/Lavalink.kt)         | Kotlin   | Kord/JDA/**Any**                           | Kotlin Coroutines      |
+| [DisGoLink](https://github.com/disgoorg/disgolink)               | Go       | **Any**                                    |                        |
+| [Mafic](https://github.com/ooliver1/mafic)                       | Python   | discord.py **V2**/nextcord/disnake/py-cord |                        |
+| [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)         | Node.js  | **Any**                                    |                        |
+| [Magmastream](https://github.com/Blackfort-Hosting/magmastream)  | Node.js  | **Any**                                    |                        |
+| [Lavacord](https://github.com/lavacord/Lavacord)                 | Node.js  | **Any**                                    |                        |
+| [Shoukaku](https://github.com/Deivu/Shoukaku)                    | Node.js  | **Any**                                    |                        |
+| [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client) | Node.js  | **Any**                                    |                        |
+| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)    | .NET     | DisCatSharp                                | v10.4.2+               |
+| [Coglink](https://github.com/PerformanC/Coglink)                 | C        | Concord                                    |                        |
+| [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)          | Rust     | **Any**                                    | `tokio`-based          |
 
 <details>
 <summary>v3.7 supporting Client Libraries</summary>
@@ -118,17 +118,17 @@ Version numbers can come in different combinations, depending on the release typ
 | Client                                                        | Platform | Compatible With                            | Additional Information          |
 |---------------------------------------------------------------|----------|--------------------------------------------|---------------------------------|
 | [Lavalink.kt](https://github.com/DRSchlaubi/lavalink.kt)      | Kotlin   | JDA/Kord/**Any**                           | Kotlin Coroutines               |
-| [DisGoLink](https://github.com/disgoorg/disgolink)            | Go       | **Any**                                    |                                 |
 | [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)     | Python   | **Any\***                                  | *`asyncio`-based libraries only |
 | [Mafic](https://github.com/ooliver1/mafic)                    | Python   | discord.py **V2**/nextcord/disnake/py-cord |                                 |
-| [Pomice](https://github.com/cloudwithax/pomice)               | Python   | discord.py **V2**                          |                                 |
 | [Wavelink](https://github.com/PythonistaGuild/Wavelink)       | Python   | discord.py **V2**                          |                                 |
-| [Cosmicord.js](https://github.com/SudhanPlayz/Cosmicord.js)   | Node.js  | **Any**                                    |                                 |
+| [Pomice](https://github.com/cloudwithax/pomice)               | Python   | discord.py **V2**                          |                                 |
 | [Lavacord](https://github.com/lavacord/lavacord)              | Node.js  | **Any**                                    |                                 |
 | [Poru](https://github.com/parasop/poru)                       | Node.js  | **Any**                                    |                                 |
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                 | Node.js  | **Any**                                    |                                 |
+| [Cosmicord.js](https://github.com/SudhanPlayz/Cosmicord.js)   | Node.js  | **Any**                                    |                                 |
 | [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp) | .NET     | DisCatSharp                                | Only prior v10.4.1              |
 | [Nomia](https://github.com/DHCPCD9/Nomia)                     | .NET     | DSharpPlus                                 |                                 |
+| [DisGoLink](https://github.com/disgoorg/disgolink)            | Go       | **Any**                                    |                                 |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -98,18 +98,19 @@ Version numbers can come in different combinations, depending on the release typ
 ---
 
 ## Client libraries:
-| Client                                                          | Platform | Compatible With                            | Additional Information |
-|-----------------------------------------------------------------|----------|--------------------------------------------|------------------------|
-| [Lavalink.kt](https://github.com/DRSchlaubi/Lavalink.kt)        | Kotlin   | Kord/JDA/**Any**                           | Kotlin Coroutines      |
-| [DisGoLink](https://github.com/disgoorg/disgolink)              | Go       | **Any**                                    |                        |
-| [Mafic](https://github.com/ooliver1/mafic)                      | Python   | discord.py **V2**/nextcord/disnake/py-cord |                        |
-| [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)        | Node.js  | **Any**                                    |                        |
-| [Magmastream](https://github.com/Blackfort-Hosting/magmastream) | Node.js  | **Any**                                    |                        |
-| [Lavacord](https://github.com/lavacord/Lavacord)                | Node.js  | **Any**                                    |                        |
-| [Shoukaku](https://github.com/Deivu/Shoukaku)                   | Node.js  | **Any**                                    |                        |
-| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)   | .NET     | DisCatSharp                                | v10.4.2+               |
-| [Coglink](https://github.com/PerformanC/Coglink)                | C        | Concord                                    |                        |
-| [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)         | Rust     | **Any**                                    | `tokio`-based          |
+| Client                                                           | Platform | Compatible With                            | Additional Information                 |
+|------------------------------------------------------------------|----------|--------------------------------------------|----------------------------------------|
+| [Lavalink.kt](https://github.com/DRSchlaubi/Lavalink.kt)         | Kotlin   | Kord/JDA/**Any**                           | Kotlin Coroutines                      |
+| [Coglink](https://github.com/PerformanC/Coglink)                 | C        | Concord                                    |                                        |
+| [DisGoLink](https://github.com/disgoorg/disgolink)               | Go       | **Any**                                    |                                        |
+| [Mafic](https://github.com/ooliver1/mafic)                       | Python   | discord.py **V2**/nextcord/disnake/py-cord |                                        |
+| [Lavacord](https://github.com/lavacord/Lavacord)                 | Node.js  | **Any**                                    |                                        |
+| [Lavalink-client](https://github.com/tomato6966/lavalink-client) | Node.js  | **Any Discord Wrapper** (TS, (c/m)JS, ESM) | v4-only, automated, custom queue-store |
+| [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)         | Node.js  | **Any**                                    |                                        |
+| [Magmastream](https://github.com/Blackfort-Hosting/magmastream)  | Node.js  | **Any**                                    |                                        |
+| [Shoukaku](https://github.com/Deivu/Shoukaku)                    | Node.js  | **Any**                                    |                                        |
+| [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)          | Rust     | **Any**                                    | `tokio`-based                          |
+| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)    | .NET     | DisCatSharp                                | v10.4.2+                               |
 
 <details>
 <summary>v3.7 supporting Client Libraries</summary>
@@ -117,17 +118,17 @@ Version numbers can come in different combinations, depending on the release typ
 | Client                                                        | Platform | Compatible With                            | Additional Information          |
 |---------------------------------------------------------------|----------|--------------------------------------------|---------------------------------|
 | [Lavalink.kt](https://github.com/DRSchlaubi/lavalink.kt)      | Kotlin   | JDA/Kord/**Any**                           | Kotlin Coroutines               |
+| [DisGoLink](https://github.com/disgoorg/disgolink)            | Go       | **Any**                                    |                                 |
 | [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)     | Python   | **Any\***                                  | *`asyncio`-based libraries only |
 | [Mafic](https://github.com/ooliver1/mafic)                    | Python   | discord.py **V2**/nextcord/disnake/py-cord |                                 |
-| [Wavelink](https://github.com/PythonistaGuild/Wavelink)       | Python   | discord.py **V2**                          |                                 |
 | [Pomice](https://github.com/cloudwithax/pomice)               | Python   | discord.py **V2**                          |                                 |
+| [Wavelink](https://github.com/PythonistaGuild/Wavelink)       | Python   | discord.py **V2**                          |                                 |
+| [Cosmicord.js](https://github.com/SudhanPlayz/Cosmicord.js)   | Node.js  | **Any**                                    |                                 |
 | [Lavacord](https://github.com/lavacord/lavacord)              | Node.js  | **Any**                                    |                                 |
 | [Poru](https://github.com/parasop/poru)                       | Node.js  | **Any**                                    |                                 |
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                 | Node.js  | **Any**                                    |                                 |
-| [Cosmicord.js](https://github.com/SudhanPlayz/Cosmicord.js)   | Node.js  | **Any**                                    |                                 |
 | [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp) | .NET     | DisCatSharp                                | Only prior v10.4.1              |
 | [Nomia](https://github.com/DHCPCD9/Nomia)                     | .NET     | DSharpPlus                                 |                                 |
-| [DisGoLink](https://github.com/disgoorg/disgolink)            | Go       | **Any**                                    |                                 |
 
 </details>
 


### PR DESCRIPTION
Hello.
I'd like to apply to add my own lavalink-client for v4 only.

In the past I've been maintaining my fork of erela.js, after some time, I decided to create a similar project with different branding and far more features + optimizations to not confess hate or other things.
I'm like 95% done for lavalink-features. and the only things that might change are: couple internal typing names. Or I'm gonna add features. In the docs it's state that i EST to finish it end of august, but I think i'll be done way earlier (in fact i already use it in production)
Also I'm currently writing excessive docs for it, so no worries.
It's both for beginners and profeciants. For beginners due to it's automated features like: Channel Delete detection, automated queue, simple typing style (almost the same like on lavalink) Validators and verificators (for example for links, plugins, sources). Which leads to less-errors during production. It's also suitable for advanced projects, hence it supports remote queue store(s) for stuff like redis, dragonflydb, psql, etc. etc. and included autoplay functions as well as high memory efficiency and modern code-style. That's why I chose to code it in typescript to support: old cjs, mjs, esm and ts code projects.

Additionally, if I get approved, I'd be greatful to be contacted on discord (chrissy8283) to retrieve my "own support channel" with Github integration webhook. Thank you very much.

If you want me to not name it "lavalink-client", I am flexible and can change it.
*Note the contributer of the github project, didn't do anything of that lavalink client, only for an old project, who then made poru.*

Also I applied sorting algorithmn to the Lavalink Clients:

1st Java Based Languages
then Languages sorted by alphabet
then Client-Names sorted by alphabet

Thanks in advance.

