### PR TITLE
Change the default max heap allocation to java default

### DIFF
--- a/LavalinkServer/docker/Dockerfile
+++ b/LavalinkServer/docker/Dockerfile
@@ -12,4 +12,4 @@ USER lavalink
 
 COPY LavalinkServer/build/libs/Lavalink.jar Lavalink.jar
 
-ENTRYPOINT ["java", "-Djdk.tls.client.protocols=TLSv1.1,TLSv1.2", "-Xmx4G", "-jar", "Lavalink.jar"]
+ENTRYPOINT ["java", "-Djdk.tls.client.protocols=TLSv1.1,TLSv1.2", "-jar", "Lavalink.jar"]

--- a/LavalinkServer/docker/alpine.Dockerfile
+++ b/LavalinkServer/docker/alpine.Dockerfile
@@ -14,4 +14,4 @@ USER lavalink
 
 COPY LavalinkServer/build/libs/Lavalink-musl.jar Lavalink.jar
 
-ENTRYPOINT ["java", "-Djdk.tls.client.protocols=TLSv1.1,TLSv1.2", "-Xmx4G", "-jar", "Lavalink.jar"]
+ENTRYPOINT ["java", "-Djdk.tls.client.protocols=TLSv1.1,TLSv1.2", "-jar", "Lavalink.jar"]

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Group=<usr>
 WorkingDirectory=</home/usr/lavalink>
 
 # The command to start Lavalink
-ExecStart=java -Xmx4G -jar </home/usr/lavalink>/Lavalink.jar
+ExecStart=java -Xmx1G -jar </home/usr/lavalink>/Lavalink.jar
 
 # Restart the service if it crashes
 Restart=on-failure
@@ -304,7 +304,7 @@ services:
         container_name: lavalink
         restart: unless-stopped
         environment:
-            - _JAVA_OPTIONS=-Xmx6G # set Java options here
+            - _JAVA_OPTIONS=-Xmx1G # set Java options here
             - SERVER_PORT=2333 # set lavalink server port
             - LAVALINK_SERVER_PASSWORD=youshallnotpass # set password for lavalink
         volumes:


### PR DESCRIPTION
4Gb seems too high, and leads to the jvm under garbage collecting, meaning higher memory usage than necessary.

This is fixable by simply asking it to use less memory. This patch would make it so less people complain about memory usage. Maybe.