### PR TITLE
default lavalink plugin repository

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -13,8 +13,8 @@ lavalink:
 #      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
 #      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
 #  pluginsDir: "./plugins" # optional, defaults to "./plugins"
-#  defaultPluginRepository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
-#  defaultPluginSnapshotRepository: "https://maven.example.com/snapshots" # optional, defaults to the Lavalink snapshot repository
+#  defaultPluginRepository: "https://maven.lavalink.dev/releases" # optional, defaults to the Lavalink release repository
+#  defaultPluginSnapshotRepository: "https://maven.lavalink.dev/snapshots" # optional, defaults to the Lavalink snapshot repository
   server:
     password: "youshallnotpass"
     sources:

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -9,7 +9,7 @@ plugins:
 #    another_key: another_value
 lavalink:
   plugins:
-#    - dependency: "com.github.example:example-plugin:1.0.0" # required, the dependency to your plugin
+#    - dependency: "com.github.example:example-plugin:1.0.0" # required, the coordinates of your plugin
 #      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
 #      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
 #  pluginsDir: "./plugins" # optional, defaults to "./plugins"

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -1,15 +1,20 @@
 server: # REST and WS server
   port: 2333
   address: 0.0.0.0
+  http2:
+    enabled: false # Whether to enable HTTP/2 support
 plugins:
 #  name: # Name of the plugin
 #    some_key: some_value # Some key-value pair for the plugin
 #    another_key: another_value
 lavalink:
   plugins:
-#    - dependency: "group:artifact:version"
-#      repository: "repository"
-  pluginsDir: "./plugins"
+#    - dependency: "com.github.example:example-plugin:1.0.0" # required, the dependency to your plugin
+#      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
+#      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
+#  pluginsDir: "./plugins" # optional, defaults to "./plugins"
+#  defaultPluginRepository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
+#  defaultPluginSnapshotRepository: "https://maven.example.com/snapshots" # optional, defaults to the Lavalink snapshot repository
   server:
     password: "youshallnotpass"
     sources:

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -10,7 +10,7 @@ plugins:
 lavalink:
   plugins:
 #    - dependency: "com.github.example:example-plugin:1.0.0" # required, the coordinates of your plugin
-#      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
+#      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink releases repository by default
 #      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
 #  pluginsDir: "./plugins" # optional, defaults to "./plugins"
 #  defaultPluginRepository: "https://maven.lavalink.dev/releases" # optional, defaults to the Lavalink release repository

--- a/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginManager.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginManager.kt
@@ -48,12 +48,12 @@ class PluginManager(val config: PluginsConfig) {
 
         val declarations = config.plugins.map { declaration ->
             if (declaration.dependency == null) throw RuntimeException("Illegal dependency declaration: null")
-            if (declaration.repository == null) {
-                declaration.repository = if (declaration.snapshot) config.defaultPluginSnapshotRepository else config.defaultPluginRepository
-            }
             val fragments = declaration.dependency!!.split(":")
             if (fragments.size != 3) throw RuntimeException("Invalid dependency \"${declaration.dependency}\"")
-            val repository =
+
+            var repository = declaration.repository
+                ?: if (declaration.snapshot) config.defaultPluginSnapshotRepository else config.defaultPluginRepository
+            repository =
                 if (declaration.repository!!.endsWith("/")) declaration.repository!! else declaration.repository!! + "/"
             Declaration(fragments[0], fragments[1], fragments[2], repository)
         }

--- a/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginManager.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginManager.kt
@@ -47,7 +47,10 @@ class PluginManager(val config: PluginsConfig) {
         data class Declaration(val group: String, val name: String, val version: String, val repository: String)
 
         val declarations = config.plugins.map { declaration ->
-            if (declaration.dependency == null || declaration.repository == null) throw RuntimeException("Illegal declaration $declaration")
+            if (declaration.dependency == null) throw RuntimeException("Illegal dependency declaration: null")
+            if (declaration.repository == null) {
+                declaration.repository = if (declaration.snapshot) config.defaultPluginSnapshotRepository else config.defaultPluginRepository
+            }
             val fragments = declaration.dependency!!.split(":")
             if (fragments.size != 3) throw RuntimeException("Invalid dependency \"${declaration.dependency}\"")
             val repository =

--- a/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginsConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginsConfig.kt
@@ -8,9 +8,12 @@ import org.springframework.stereotype.Component
 class PluginsConfig {
     var plugins: List<PluginDeclaration> = emptyList()
     var pluginsDir: String = "./plugins"
+    var defaultPluginRepository: String = "https://maven.lavalink.dev/releases"
+    var defaultPluginSnapshotRepository: String = "https://maven.lavalink.dev/snapshots"
 }
 
 data class PluginDeclaration(
     var dependency: String? = null,
-    var repository: String? = null
+    var repository: String? = null,
+    var snapshot: Boolean = false
 )

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -19,6 +19,36 @@ for instructions.
 
 You can add your own plugin by submitting a pull-request to this file.
 
+## Official plugin repository
+
+The official plugin repository is hosted on https://maven.lavalink.dev. If you want to publish your plugin there, please reach out to us via [Discord](https://discord.gg/ZW4s47Ppw4) for credentials.
+The repository has a release (https://maven.lavalink.dev/releases) and snapshot (https://maven.lavalink.dev/snapshots) repository which you can use to publish your plugin.
+By default, Lavalink will look for the plugin in the Lavalink repository, but you can also specify a custom repository for each plugin in your `application.yml` file.
+
+```yaml
+
+lavalink:
+  plugins:
+    - dependency: "com.github.example:example-plugin:1.0.0" # required, the dependency to your plugin
+      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
+      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
+```
+
+The default repository can also be overwritten in your `application.yml` file.
+
+```yaml
+lavalink:
+  defaultPluginRepository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
+  defaultPluginSnapshotRepository: "https://maven.example.com/snapshots" # optional, defaults to the Lavalink snapshot repository
+```
+
+Additionally, you can overwrite the default plugin folder where Lavalink saves the downloaded plugins, or loads them from.
+
+```yaml
+lavalink:
+  pluginsDir: "./lavalink-plugins" # optional, defaults to "./plugins"
+```
+
 ## Developing your own plugin
 
 > **Note:**  

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -19,10 +19,10 @@ for instructions.
 
 You can add your own plugin by submitting a pull-request to this file.
 
-## Official plugin repository
+## Distributing your plugin
 
 The official plugin repository is hosted on https://maven.lavalink.dev. If you want to publish your plugin there, please reach out to us via [Discord](https://discord.gg/ZW4s47Ppw4) for credentials.
-The repository has a release (https://maven.lavalink.dev/releases) and snapshot (https://maven.lavalink.dev/snapshots) repository which you can use to publish your plugin.
+The Lavalink team has release (https://maven.lavalink.dev/releases) and snapshot (https://maven.lavalink.dev/snapshots) repositories which you can use to publish your plugin.
 By default, Lavalink will look for the plugin in the Lavalink repository, but you can also specify a custom repository for each plugin in your `application.yml` file.
 
 ```yaml
@@ -30,19 +30,19 @@ By default, Lavalink will look for the plugin in the Lavalink repository, but yo
 lavalink:
   plugins:
     - dependency: "com.github.example:example-plugin:1.0.0" # required, the dependency to your plugin
-      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
+      repository: "https://maven.example.com/releases" # optional, defaults to https://maven.lavalink.dev/releases for releases
       snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
 ```
 
-The default repository can also be overwritten in your `application.yml` file.
+The default repositories can also be overridden in your `application.yml` file.
 
 ```yaml
 lavalink:
-  defaultPluginRepository: "https://maven.example.com/releases" # optional, defaults to the Lavalink release repository
-  defaultPluginSnapshotRepository: "https://maven.example.com/snapshots" # optional, defaults to the Lavalink snapshot repository
+  defaultPluginRepository: "https://maven.example.com/releases" # optional, defaults to https://maven.lavalink.dev/releases
+  defaultPluginSnapshotRepository: "https://maven.example.com/snapshots" # optional, defaults to https://maven.lavalink.dev/snapshots
 ```
 
-Additionally, you can overwrite the default plugin folder where Lavalink saves the downloaded plugins, or loads them from.
+Additionally, you can override the default plugin path where Lavalink saves and loads the downloaded plugins.
 
 ```yaml
 lavalink:


### PR DESCRIPTION
This adds a setting to set a default Lavalink repository, which Lavalink will default to if no repository is provided

This aims to make all plugins easily available & accessible in a central repository