### PR TITLE
release 4.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+## 4.0.0-beta.5
+* Update lavaplayer to [`2.0.3`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.0.2) - Fixed YouTube access token errors
+
 ## 4.0.0-beta.4
 * Update lavaplayer to [`2.0.2`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.0.2) - Support MPEG 2.5 and fixed some requests not timing out
 * Add `Omissible#isPresent` & `Omissible#isOmitted` to the `protocol` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The most noteworthy of these, as well as any features and breaking changes, are 
 
 ## 4.0.0-beta.5
 * Update lavaplayer to [`2.0.3`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.0.2) - Fixed YouTube access token errors
+* Added default plugin repository. Plugin devs can now request their plugin to be added to the default repository. For more info see [here](https://github.com/lavalink-devs/Lavalink/blob/master/PLUGINS.md#distributing-your-plugin)
+* Fixed error when seeking and player is not playing anything in 
 
 ## 4.0.0-beta.4
 * Update lavaplayer to [`2.0.2`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.0.2) - Support MPEG 2.5 and fixed some requests not timing out

--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -1,15 +1,20 @@
 server: # REST and WS server
   port: 2333
   address: 0.0.0.0
+  http2:
+    enabled: false # Whether to enable HTTP/2 support
 plugins:
 #  name: # Name of the plugin
 #    some_key: some_value # Some key-value pair for the plugin
 #    another_key: another_value
 lavalink:
   plugins:
-#    - dependency: "group:artifact:version"
-#      repository: "repository"
-  pluginsDir: "./plugins"
+#    - dependency: "com.github.example:example-plugin:1.0.0" # required, the coordinates of your plugin
+#      repository: "https://maven.example.com/releases" # optional, defaults to the Lavalink releases repository by default
+#      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
+#  pluginsDir: "./plugins" # optional, defaults to "./plugins"
+#  defaultPluginRepository: "https://maven.lavalink.dev/releases" # optional, defaults to the Lavalink release repository
+#  defaultPluginSnapshotRepository: "https://maven.lavalink.dev/snapshots" # optional, defaults to the Lavalink snapshot repository
   server:
     password: "youshallnotpass"
     sources:

--- a/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginManager.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginManager.kt
@@ -47,10 +47,13 @@ class PluginManager(val config: PluginsConfig) {
         data class Declaration(val group: String, val name: String, val version: String, val repository: String)
 
         val declarations = config.plugins.map { declaration ->
-            if (declaration.dependency == null || declaration.repository == null) throw RuntimeException("Illegal declaration $declaration")
+            if (declaration.dependency == null) throw RuntimeException("Illegal dependency declaration: null")
             val fragments = declaration.dependency!!.split(":")
             if (fragments.size != 3) throw RuntimeException("Invalid dependency \"${declaration.dependency}\"")
-            val repository =
+
+            var repository = declaration.repository
+                ?: if (declaration.snapshot) config.defaultPluginSnapshotRepository else config.defaultPluginRepository
+            repository =
                 if (declaration.repository!!.endsWith("/")) declaration.repository!! else declaration.repository!! + "/"
             Declaration(fragments[0], fragments[1], fragments[2], repository)
         }

--- a/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginsConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/bootstrap/PluginsConfig.kt
@@ -8,9 +8,12 @@ import org.springframework.stereotype.Component
 class PluginsConfig {
     var plugins: List<PluginDeclaration> = emptyList()
     var pluginsDir: String = "./plugins"
+    var defaultPluginRepository: String = "https://maven.lavalink.dev/releases"
+    var defaultPluginSnapshotRepository: String = "https://maven.lavalink.dev/snapshots"
 }
 
 data class PluginDeclaration(
     var dependency: String? = null,
-    var repository: String? = null
+    var repository: String? = null,
+    var snapshot: Boolean = false
 )

--- a/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
@@ -124,8 +124,10 @@ class PlayerRestHandler(
         // we handle position differently for playing new tracks
         playerUpdate.position.takeIfPresent { encodedTrack is Omissible.Omitted && playerUpdate.identifier is Omissible.Omitted }
             ?.let {
-                player.seekTo(it)
-                SocketServer.sendPlayerUpdate(context, player)
+                if (player.isPlaying) {
+                    player.seekTo(it)
+                    SocketServer.sendPlayerUpdate(context, player)
+                }
             }
 
         playerUpdate.endTime.takeIfPresent { encodedTrack is Omissible.Omitted && playerUpdate.identifier is Omissible.Omitted }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -19,6 +19,36 @@ for instructions.
 
 You can add your own plugin by submitting a pull-request to this file.
 
+## Distributing your plugin
+
+The official plugin repository is hosted on https://maven.lavalink.dev. If you want to publish your plugin there, please reach out to us via [Discord](https://discord.gg/ZW4s47Ppw4) for credentials.
+The Lavalink team has release (https://maven.lavalink.dev/releases) and snapshot (https://maven.lavalink.dev/snapshots) repositories which you can use to publish your plugin.
+By default, Lavalink will look for the plugin in the Lavalink repository, but you can also specify a custom repository for each plugin in your `application.yml` file.
+
+```yaml
+
+lavalink:
+  plugins:
+    - dependency: "com.github.example:example-plugin:1.0.0" # required, the dependency to your plugin
+      repository: "https://maven.example.com/releases" # optional, defaults to https://maven.lavalink.dev/releases for releases
+      snapshot: false # optional, defaults to false, used to tell Lavalink to use the snapshot repository instead of the release repository
+```
+
+The default repositories can also be overridden in your `application.yml` file.
+
+```yaml
+lavalink:
+  defaultPluginRepository: "https://maven.example.com/releases" # optional, defaults to https://maven.lavalink.dev/releases
+  defaultPluginSnapshotRepository: "https://maven.example.com/snapshots" # optional, defaults to https://maven.lavalink.dev/snapshots
+```
+
+Additionally, you can override the default plugin path where Lavalink saves and loads the downloaded plugins.
+
+```yaml
+lavalink:
+  pluginsDir: "./lavalink-plugins" # optional, defaults to "./plugins"
+```
+
 ## Developing your own plugin
 
 > **Note:**  

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ fun VersionCatalogBuilder.spring() {
 }
 
 fun VersionCatalogBuilder.voice() {
-    version("lavaplayer", "2.0.2")
+    version("lavaplayer", "2.0.3")
 
     library("lavaplayer",            "dev.arbjerg", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "dev.arbjerg", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")


### PR DESCRIPTION

* Update lavaplayer to [`2.0.3`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.0.2) - Fixed YouTube access token errors
* Added default plugin repository. Plugin devs can now request their plugin to be added to the default repository. For more info see [here](https://github.com/lavalink-devs/Lavalink/blob/master/PLUGINS.md#distributing-your-plugin)
* Fixed error when seeking and player is not playing anything in 