### PR TITLE
Add nyxx_lavalink to clients

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -23,6 +23,8 @@ description: A list of Lavalink client libraries.
 | [Lavalink4NET](https://github.com/angelobreuer/Lavalink4NET)        | .NET            | Discord.Net/DSharpPlus/Remora              | v4+                            |
 | [Coglink](https://github.com/PerformanC/Coglink)                    | C               | Concord                                    |                                |
 | [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)             | Rust, Python    | **Any**                                    | `tokio`-based, `asyncio`-based |
+| [lavalink](https://github.com/nyxx-discord/nyxx_lavalink)           | Dart            | **Any**                                    |                                |
+| [nyxx_lavalink](https://github.com/nyxx-discord/nyxx_lavalink)      | Dart            | nyxx                                       |                                |
 
 <details markdown="1">
 <summary>v3.7 supporting Client Libraries</summary>

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -23,8 +23,7 @@ description: A list of Lavalink client libraries.
 | [Lavalink4NET](https://github.com/angelobreuer/Lavalink4NET)        | .NET            | Discord.Net/DSharpPlus/Remora              | v4+                            |
 | [Coglink](https://github.com/PerformanC/Coglink)                    | C               | Concord                                    |                                |
 | [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)             | Rust, Python    | **Any**                                    | `tokio`-based, `asyncio`-based |
-| [lavalink](https://github.com/nyxx-discord/nyxx_lavalink)           | Dart            | **Any**                                    |                                |
-| [nyxx_lavalink](https://github.com/nyxx-discord/nyxx_lavalink)      | Dart            | nyxx                                       |                                |
+| [lavalink](https://github.com/nyxx-discord/nyxx_lavalink)           | Dart            | nyxx/**Any**                               |                                |
 
 <details markdown="1">
 <summary>v3.7 supporting Client Libraries</summary>


### PR DESCRIPTION
Adds the `lavalink` and `nyxx_lavalink` clients for Dart to the client list.

`lavalink` is library-agnostic and `nyxx_lavalink` establishes a bridge between it and the `nyxx` library. They are both hosted in a monorepo, which is why the repository link is the same.
Currently the packages are only available on the `feat/nyxx-6.0.0` branch in that repository, but they will be available on `main` once `nyxx_lavalink` v4 comes out of beta.