### PR TITLE
Remove deprecated version line in docker compose files

### DIFF
--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -12,8 +12,6 @@ Install [Docker](https://docs.docker.com/engine/install/) & [Docker Compose](htt
 Create a `docker-compose.yml` with the following content:
 
 ```yaml title="docker-compose.yml"
-version: "3.8"
-
 services:
   lavalink:
     # pin the image version to Lavalink v4

--- a/docs/docker/docker-compose.yml
+++ b/docs/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mkdocs:
     build:


### PR DESCRIPTION
This PR removes the `version: 'x.x'` lines in docker-compose file and documentation.

![2024-03-26_19-01](https://github.com/lavalink-devs/Lavalink/assets/45038833/b6bf24cb-756c-4bd7-9773-8e27cc9a2f82)
