### PR TITLE
Expose lavalink sessions for plugins

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/util/util.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/util/util.kt
@@ -122,7 +122,7 @@ fun getRootCause(throwable: Throwable?): Throwable {
 }
 
 fun socketContext(socketServer: SocketServer, sessionId: String) =
-    socketServer.contextMap[sessionId] ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found")
+    socketServer.sessions[sessionId] ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found")
 
 fun existingPlayer(socketContext: SocketContext, guildId: Long) =
     socketContext.players[guildId] ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Player not found")

--- a/plugin-api/src/main/java/dev/arbjerg/lavalink/api/ISocketServer.kt
+++ b/plugin-api/src/main/java/dev/arbjerg/lavalink/api/ISocketServer.kt
@@ -1,0 +1,17 @@
+package dev.arbjerg.lavalink.api
+
+/**
+ * Represents a Lavalink server which handles WebSocket connections.
+ */
+interface ISocketServer {
+    /**
+     * A map of all active sessions by their session id.
+     */
+    val sessions: Map<String, ISocketContext>
+
+    /**
+     * A map of all resumable sessions by their session id.
+     * A session is resumable if the client configured resuming and has disconnected.
+     */
+    val resumableSessions: Map<String, ISocketContext>
+}


### PR DESCRIPTION
This pr adds the ability for plugins to easily access the sessions without having to import the lavalink server as a dependency

in some plugins i want to have rest routes such as `/v4/sessions/{SESSION_ID}/players/{GUILD_ID}`

this is rather annoying atm since you have to add the lavalink server as a compile only dependency