### PR TITLE
Add fixes to documentation

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -1072,7 +1072,11 @@ Additionally, there are a few REST endpoints for the ip rotation extension.
 GET /v4/routeplanner/status
 ```
 
-Response:
+Responses:
+
+204 - No Content: This means the RoutePlanner is not enabled on the server.
+
+200 - Content: This means that the RoutePlanner has been enabled, and will give the following information.
 
 | Field   | Type                                        | Description                                                           |
 |---------|---------------------------------------------|-----------------------------------------------------------------------|

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -917,7 +917,7 @@ Parsed [Semantic Versioning 2.0.0](https://semver.org/)
 ```json
 {
   "version": {
-    "string": "3.7.0-rc.1+test",
+    "semver": "3.7.0-rc.1+test",
     "major": 3,
     "minor": 7,
     "patch": 0,


### PR DESCRIPTION
This PR fixes the following:

A mistake in a example payload, where it was supposed to be `semver`, but instead it was `string`

Adds a 204 No content on the `/v4/routeplanner/status` endpoint, which is received when the routeplanner is disabled.

I would like to say, that the way it has been written, is not perfect, so let me know if it needs changes.