### PR TITLE
release v4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+## v4.0.6
+* Updated Lavaplayer to [`2.2.0`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.2.0)
+
 ## v4.0.5
 * Updated Lavaplayer to [`2.1.2`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2)
 * Updated Koe to [`2.0.1`](https://github.com/KyokoBot/koe/releases/tag/2.0.1) (fixes the `IndexOutOfBoundsException` when playing a YouTube track)
@@ -13,7 +16,7 @@ The most noteworthy of these, as well as any features and breaking changes, are 
 > The default Youtube source is now deprecated and won't receive further updates. Please use https://github.com/lavalink-devs/youtube-source#plugin instead.
 
 ## v4.0.4
-* Update Lavaplayer to [`2.1.1`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.1)
+* Updated Lavaplayer to [`2.1.1`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.1)
 
 ## v4.0.3
 * Fixed plugins not registering (introduced in [`4.0.2`](https://github.com/lavalink-devs/Lavalink/releases/tag/4.0.2))

--- a/docs/changelog/v4.md
+++ b/docs/changelog/v4.md
@@ -1,3 +1,6 @@
+## v4.0.6
+* Updated Lavaplayer to [`2.2.0`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.2.0)
+
 ## v4.0.5
 * Updated Lavaplayer to [`2.1.2`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.1.2)
 * Updated Koe to [`2.0.1`](https://github.com/KyokoBot/koe/releases/tag/2.0.1) (fixes the `IndexOutOfBoundsException` when playing a YouTube track)


### PR DESCRIPTION
## v4.0.6
* Updated Lavaplayer to [`2.2.0`](https://github.com/lavalink-devs/lavaplayer/releases/tag/2.2.0)