### PR TITLE
Allow usage of non-allocating frame buffers

### DIFF
--- a/LavalinkServer/application.yml.example
+++ b/LavalinkServer/application.yml.example
@@ -38,6 +38,7 @@ lavalink:
       rotation: true
       channelMix: true
       lowPass: true
+    nonAllocatingFrameBuffer: false # Setting to true reduces the number of allocations made by each player at the expense of frame rebuilding (e.g. non-instantaneous volume changes)
     bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Duration <= 0 to disable JDA-NAS. Minimum of 40ms, lower values may introduce pauses.
     frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
     opusEncodingQuality: 10 # Opus encoder quality. Valid values range from 0 to 10, where 10 is best quality but is the most expensive on the CPU.

--- a/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/AudioPlayerConfiguration.kt
@@ -14,6 +14,7 @@ import com.sedmelluq.discord.lavaplayer.source.soundcloud.*
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager
+import com.sedmelluq.discord.lavaplayer.track.playback.NonAllocatingAudioFrameBuffer
 import com.sedmelluq.lava.extensions.youtuberotator.YoutubeIpRotatorSetup
 import com.sedmelluq.lava.extensions.youtuberotator.planner.*
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv4Block
@@ -53,6 +54,11 @@ class AudioPlayerConfiguration {
 
         if (serverConfig.isGcWarnings) {
             audioPlayerManager.enableGcMonitoring()
+        }
+
+        if (serverConfig.isNonAllocatingFrameBuffer) {
+            log.info("Using a non-allocating frame buffer")
+            audioPlayerManager.configuration.setFrameBufferFactory(::NonAllocatingAudioFrameBuffer)
         }
 
         val defaultFrameBufferDuration = audioPlayerManager.frameBufferDuration

--- a/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/ServerConfig.kt
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component
 @Component
 class ServerConfig {
     var password: String? = null
+    var isNonAllocatingFrameBuffer = false
     var bufferDurationMs: Int? = null
     var frameBufferDurationMs: Int? = null
     var opusEncodingQuality: Int? = null


### PR DESCRIPTION
This PR introduces a config option for toggling the use of non-allocating frame buffers.

In a high traffic environment, this can reduce pressure on the garbage collector by allowing each player to use a frame buffer specifically designed to reduce allocations by directly passing audio between byte buffers created at initialisation rather than when copying data outside of the player's control (i.e. user code). This should also have a positive effect by reducing CPU usage, thus increasing server performance.