### PR TITLE
Implement shutdown handling to close WS clients cleanly

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/ShutdownHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/ShutdownHandler.kt
@@ -1,0 +1,16 @@
+package lavalink.server.io
+
+import org.springframework.web.socket.CloseStatus
+
+class ShutdownHandler(private val socketServer: SocketServer) : Thread("lavalink-shutdown-handler") {
+    init {
+        isDaemon = false // we want this thread to block shutdown until it has finished running
+    }
+
+    override fun run() {
+        socketServer.contexts.forEach {
+            // don't care about exceptions here, the JVM's shutting down anyway.
+            it.runCatching { closeWebSocket(CloseStatus.GOING_AWAY.code) }
+        }
+    }
+}

--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -56,6 +56,10 @@ final class SocketServer(
     private val statsCollector = StatsCollector(this)
     private val charPool = ('a'..'z') + ('0'..'9')
 
+    init {
+        Runtime.getRuntime().addShutdownHook(ShutdownHandler(this))
+    }
+
     companion object {
         private val log = LoggerFactory.getLogger(SocketServer::class.java)
 


### PR DESCRIPTION
Lavalink does not currently implement a shutdown hook to close connected websocket clients. As a result, clients will see their websocket connections improperly closed, typically with code `1006`.

With this change, the server should now cleanly close connections with code `1001` ("GOING AWAY") when shutting down gracefully (i.e. upon receiving `SIGINT`).
