### PR TITLE
Fix: links linking to non-existing files

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -9,7 +9,7 @@ There are mainly 3 different ways to configure Lavalink:
 ## Config File
 
 This is the easiest way to configure Lavalink. You create a file called `application.yml` where you start your Lavalink server.
-See the [application.yml](config/application-yml.md) documentation for more information.
+See the [application.yml](config/file.md) documentation for more information.
 
 ## Config Server
 

--- a/docs/getting-started/binary.md
+++ b/docs/getting-started/binary.md
@@ -17,7 +17,7 @@ Create a new directory and place the `Lavalink.jar` file inside it. This will be
 ## Configuration
 
 Check out the [configuration](../configuration/index.md) page to learn how to configure Lavalink.
-The recommended way would be to use a [Config File](../configuration/config-file.md).
+The recommended way would be to use a [Config File](../configuration/config/file.md).
 
 ## Running Lavalink
 


### PR DESCRIPTION
1. https://lavalink.dev/configuration/index.html#config-file has a link "application.yml" that gives a 404 = https://lavalink.dev/configuration/config/application-yml.md
2. https://lavalink.dev/getting-started/binary#configuration has a link "Config File" resulting in a 404 = https://lavalink.dev/configuration/config-file.md