### PR TITLE
Add aqualink

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -18,6 +18,7 @@ description: A list of Lavalink client libraries.
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js            | **Any**                                    |                                    |
 | [Magmastream](https://github.com/Blackfort-Hosting/magmastream)     | Node.js            | **Any**                                    |                                    |
 | [Lavacord](https://github.com/lavacord/Lavacord)                    | Node.js/TypeScript | **Any**                                    |                                    |
+| [Aqualink](https://github.com/ToddyTheNoobDud/AquaLink)             | Node.js/TypeScript | **Any**                                    |                                    |
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                       | Node.js            | **Any**                                    |                                    |
 | [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client)    | Node.js            | **Any**                                    |                                    |
 | [FastLink](https://github.com/PerformanC/FastLink)                  | Node.js            | **Any**                                    |                                    |


### PR DESCRIPTION
hi its me again, after 7 months around.
Aqualink supports discord.js, seyfert, etc. Its also compatible with both javascript, typescript, and probably bun / deno
Supports both ts, js, mjs files

Documentation website: https://roddynnn.github.io/
Npm website: https://www.npmjs.com/package/aqualink

If this is still valid: https://github.com/lavalink-devs/Lavalink/pull/1054#issuecomment-2171925078, please tell me