### PR TITLE
Fix concurrency issue in SocketServer and address deprecations

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -51,7 +51,7 @@ final class SocketServer(
 
     // sessionID <-> Session
     override val sessions = ConcurrentHashMap<String, SocketContext>()
-    override val resumableSessions = mutableMapOf<String, SocketContext>()
+    override val resumableSessions = ConcurrentHashMap<String, SocketContext>()
     private val koe = Koe.koe(koeOptions)
     private val statsCollector = StatsCollector(this)
     private val charPool = ('a'..'z') + ('0'..'9')

--- a/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
@@ -48,6 +48,7 @@ class PlayerRestHandler(
 
     @PatchMapping("/v4/sessions/{sessionId}/players/{guildId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Suppress("DEPRECATION")
     private fun patchPlayer(
         @RequestBody playerUpdate: PlayerUpdate,
         @PathVariable sessionId: String,


### PR DESCRIPTION
This PR replaces `mutableMapOf` with `ConcurrentHashMap` for `resumableSessions` in `SocketServer.kt`. This prevents `ConcurrentModificationException` during session resumption and cleanup. It also adds `@Suppress("DEPRECATION")` to `PlayerRestHandler` to reduce build noise.