### PR TITLE
feat: add prometheus metrics for load results and track plays

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
@@ -9,12 +9,6 @@ import org.springframework.stereotype.Component
 class SearchMetrics {
     
     companion object {
-        private val searchCounter: Counter = Counter.build()
-            .name("lavalink_track_loads_total")
-            .help("Total number of tracks searched by source")
-            .labelNames("source")
-            .register()
-
         private val playCounter: Counter = Counter.build()
             .name("lavalink_tracks_played_total")
             .help("Total number of tracks played by source")
@@ -28,10 +22,6 @@ class SearchMetrics {
             .register()
     }
     
-    fun recordSearch(source: String) {
-        searchCounter.labels(source).inc()
-    }
-
     fun recordPlay(source: String, guildId: String) {
         playCounter.labels(source, guildId).inc()
     }

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
@@ -1,0 +1,33 @@
+package lavalink.server.metrics
+
+import io.prometheus.client.Counter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("metrics.prometheus.enabled")
+class SearchMetrics {
+    
+    companion object {
+        private val searchCounter: Counter = Counter.build()
+            .name("lavalink_searches_total")
+            .help("Total number of tracks searched by source")
+            .labelNames("source")
+            .register()
+
+        private val playCounter: Counter = Counter.build()
+            .name("lavalink_tracks_played_total")
+            .help("Total number of tracks played by source")
+            .labelNames("source")
+            .register()
+    }
+    
+    fun recordSearch(source: String) {
+        searchCounter.labels(source).inc()
+    }
+
+    fun recordPlay(source: String) {
+        playCounter.labels(source).inc()
+    }
+}
+

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
@@ -10,7 +10,7 @@ class SearchMetrics {
     
     companion object {
         private val searchCounter: Counter = Counter.build()
-            .name("lavalink_searches_total")
+            .name("lavalink_track_loads_total")
             .help("Total number of tracks searched by source")
             .labelNames("source")
             .register()
@@ -18,7 +18,7 @@ class SearchMetrics {
         private val playCounter: Counter = Counter.build()
             .name("lavalink_tracks_played_total")
             .help("Total number of tracks played by source")
-            .labelNames("source")
+            .labelNames("source", "guild_id")
             .register()
     }
     
@@ -26,8 +26,8 @@ class SearchMetrics {
         searchCounter.labels(source).inc()
     }
 
-    fun recordPlay(source: String) {
-        playCounter.labels(source).inc()
+    fun recordPlay(source: String, guildId: String) {
+        playCounter.labels(source, guildId).inc()
     }
 }
 

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
@@ -20,6 +20,12 @@ class SearchMetrics {
             .help("Total number of tracks played by source")
             .labelNames("source", "guild_id")
             .register()
+
+        private val loadResultCounter: Counter = Counter.build()
+            .name("lavalink_track_load_results_total")
+            .help("Total number of track load results by source and result type")
+            .labelNames("source", "result")
+            .register()
     }
     
     fun recordSearch(source: String) {
@@ -28,6 +34,10 @@ class SearchMetrics {
 
     fun recordPlay(source: String, guildId: String) {
         playCounter.labels(source, guildId).inc()
+    }
+
+    fun recordLoadResult(source: String, result: String) {
+        loadResultCounter.labels(source, result).inc()
     }
 }
 

--- a/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/metrics/SearchMetrics.kt
@@ -16,8 +16,8 @@ class SearchMetrics {
             .register()
 
         private val loadResultCounter: Counter = Counter.build()
-            .name("lavalink_track_load_results_total")
-            .help("Total number of track load results by source and result type")
+            .name("lavalink_item_load_results_total")
+            .help("Total number of audio item load results by source and result type")
             .labelNames("source", "result")
             .register()
     }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
@@ -86,7 +86,7 @@ class AudioLoaderRestHandler(
 
             else -> {
                 log.error("Unknown item type: ${item.javaClass}")
-                searchMetrics?.recordLoadResult("unknown", "unknown")
+                searchMetrics?.recordLoadResult("", "unknown")
                 throw ResponseStatusException(
                     HttpStatus.INTERNAL_SERVER_ERROR,
                     "Identifier returned unknown audio item type: ${item.javaClass.canonicalName}"
@@ -130,7 +130,7 @@ class AudioLoaderRestHandler(
         }
 
         return if (source.isNullOrBlank()) {
-            "unknown"
+            ""
         } else {
             source
         }

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
@@ -61,7 +61,7 @@ class AudioLoaderRestHandler(
             loadAudioItem(audioPlayerManager, identifier)
         } catch (ex: FriendlyException) {
             log.error("Failed to load track for identifier $identifier", ex)
-            searchMetrics?.recordLoadResult("unknown", "error")
+            searchMetrics?.recordLoadResult("", "error")
             return ResponseEntity.ok(LoadResult.loadFailed(ex))
         }
 

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
@@ -61,12 +61,12 @@ class AudioLoaderRestHandler(
             loadAudioItem(audioPlayerManager, identifier)
         } catch (ex: FriendlyException) {
             log.error("Failed to load track for identifier $identifier", ex)
-            searchMetrics?.recordLoadResult(extractSourceType(null), "load_failed")
+            searchMetrics?.recordLoadResult("unknown", "error")
             return ResponseEntity.ok(LoadResult.loadFailed(ex))
         }
 
         val (result, resultType) = when (item) {
-            null -> LoadResult.NoMatches() to "no_matches"
+            null -> LoadResult.NoMatches() to "empty"
 
             is AudioTrack -> {
                 log.info("Loaded track ${item.info.title}")
@@ -86,7 +86,7 @@ class AudioLoaderRestHandler(
 
             else -> {
                 log.error("Unknown item type: ${item.javaClass}")
-                searchMetrics?.recordLoadResult(extractSourceType(item), "error")
+                searchMetrics?.recordLoadResult("unknown", "unknown")
                 throw ResponseStatusException(
                     HttpStatus.INTERNAL_SERVER_ERROR,
                     "Identifier returned unknown audio item type: ${item.javaClass.canonicalName}"
@@ -94,8 +94,7 @@ class AudioLoaderRestHandler(
             }
         }
 
-        val source = extractSourceType(item)
-        searchMetrics?.recordLoadResult(source, resultType)
+        searchMetrics?.recordLoadResult(extractSourceType(item), resultType)
         return ResponseEntity.ok(result)
     }
 

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.kt
@@ -95,7 +95,6 @@ class AudioLoaderRestHandler(
         }
 
         val source = extractSourceType(item, identifier)
-        searchMetrics?.recordSearch(source)
         searchMetrics?.recordLoadResult(source, resultType)
         return ResponseEntity.ok(result)
     }

--- a/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
@@ -23,6 +23,7 @@ class PlayerRestHandler(
     private val filterExtensions: List<AudioFilterExtension>,
     private val pluginInfoModifiers: List<AudioPluginInfoModifier>,
     serverConfig: ServerConfig,
+    private val searchMetrics: lavalink.server.metrics.SearchMetrics? = null
 ) {
 
     companion object {
@@ -221,6 +222,7 @@ class PlayerRestHandler(
                 }
 
                 player.play(newTrack)
+                searchMetrics?.recordPlay(newTrack.sourceManager?.sourceName ?: "unknown")
                 player.provideTo(context.getMediaConnection(player))
             } ?: player.stop()
         }

--- a/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
@@ -8,6 +8,7 @@ import dev.arbjerg.lavalink.api.AudioPluginInfoModifier
 import dev.arbjerg.lavalink.protocol.v4.*
 import lavalink.server.config.ServerConfig
 import lavalink.server.io.SocketServer
+import lavalink.server.metrics.SearchMetrics
 import lavalink.server.player.filters.FilterChain
 import lavalink.server.util.*
 import moe.kyokobot.koe.VoiceServerInfo
@@ -23,7 +24,7 @@ class PlayerRestHandler(
     private val filterExtensions: List<AudioFilterExtension>,
     private val pluginInfoModifiers: List<AudioPluginInfoModifier>,
     serverConfig: ServerConfig,
-    private val searchMetrics: lavalink.server.metrics.SearchMetrics? = null
+    private val searchMetrics: SearchMetrics? = null
 ) {
 
     companion object {
@@ -222,7 +223,10 @@ class PlayerRestHandler(
                 }
 
                 player.play(newTrack)
-                searchMetrics?.recordPlay(newTrack.sourceManager?.sourceName ?: "unknown")
+                searchMetrics?.recordPlay(
+                    newTrack.sourceManager?.sourceName ?: "unknown",
+                    guildId.toString()
+                )
                 player.provideTo(context.getMediaConnection(player))
             } ?: player.stop()
         }

--- a/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
@@ -224,7 +224,7 @@ class PlayerRestHandler(
 
                 player.play(newTrack)
                 searchMetrics?.recordPlay(
-                    newTrack.sourceManager?.sourceName ?: "unknown",
+                    newTrack.sourceManager?.sourceName ?: "",
                     guildId.toString()
                 )
                 player.provideTo(context.getMediaConnection(player))


### PR DESCRIPTION
Add new prometheus metrics to track search and play activity by source:
- `lavalink_tracks_played_total{source, guildId}` - counts tracks played by source and guildId
- `lavalink_track_load_results_total{source,result}` counts load result types like search, track, playlist, no_matches, error matched with source

The `source` label is fetched from the load result when available and falls back to parsing from identifier.