### PR TITLE
docs: update docker image java versions and correct link

### DIFF
--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -12,8 +12,8 @@ Install [Docker](https://docs.docker.com/engine/install/) & [Docker Compose](htt
 | Variant      | Description                                  | Java Version | User  | Group | Example                                       |
 |--------------|----------------------------------------------|--------------|-------|-------|-----------------------------------------------|
 | `Ubuntu`     | Default variant, based on Ubuntu             | 18           | 322   | 322   | `ghcr.io/lavalink-devs/lavalink:4`            |
-| `Alpine`     | Smaller image size, based on Alpine          | 21           | 322   | 322   | `ghcr.io/lavalink-devs/lavalink:4-alpine`     |
-| `Distroless` | Even smaller image size, based on Distroless | 21           | 65534 | 65534 | `ghcr.io/lavalink-devs/lavalink:4-distroless` |
+| `Alpine`     | Smaller image size, based on Alpine          | 17           | 322   | 322   | `ghcr.io/lavalink-devs/lavalink:4-alpine`     |
+| `Distroless` | Even smaller image size, based on Distroless | 17           | 65534 | 65534 | `ghcr.io/lavalink-devs/lavalink:4-distroless` |
 
 Create a `compose.yml` with the following content:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ hide:
   url: https://prometheus.io/
 - title: Docker images
   icon: ':simple-docker:'
-  url: configuration/docker.md
+  url: getting-started/docker.md
 - title: Plugin support
   icon: ':material-power-plug-outline:'
   url: plugins.md


### PR DESCRIPTION
wrong java version documented for docker images and the homepage card for docker redirects to 404