### PR TITLE
release v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+## v4.2.1
+* Updated koe to version [`3.0.0-pre5`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre5)
+* Updated libdave to version [`0.1.0`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.0)
+
 ## v4.2.0
 > [!IMPORTANT]
 > This is the first Lavalink release with [DAVE](https://daveprotocol.com/) (E2EE voice) support.

--- a/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/KoeConfiguration.kt
@@ -35,7 +35,7 @@ class KoeConfiguration(val serverConfig: ServerConfig) {
     @Bean
     fun koeOptions(): KoeOptions = KoeOptions.builder().apply {
         setDeafened(true)
-        setEnableWSSPortOverride(false)
+        setEnableDAVELogSink(true)
 
         val systemType: SystemType? = try {
             SystemType(DefaultArchitectureTypes.detect(), DefaultOperatingSystemTypes.detect())

--- a/docs/changelog/v4.md
+++ b/docs/changelog/v4.md
@@ -1,3 +1,7 @@
+## v4.2.1
+* Updated koe to version [`3.0.0-pre5`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre5)
+* Updated libdave to version [`0.1.0`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.0)
+
 ## v4.2.0
 > [!IMPORTANT]
 > This is the first Lavalink release with [DAVE](https://daveprotocol.com/) (E2EE voice) support.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -42,6 +42,9 @@ logging:
     com.sedmelluq.discord.lavaplayer.tools.ExceptionTools: DEBUG
     # Log YouTube Plugin stuff (only needed if you have issues with YouTube)
     dev.lavalink.youtube: DEBUG
+    # Log Koe internals (only needed if you have issues with Koe/DAVE)
+    moe.kyokobot.koe.internal.dave: TRACE
+    moe.kyokobot.koe.internal.gateway: TRACE
 
   # This will log all requests to the REST API
   request:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,7 @@ fun VersionCatalogBuilder.spring() {
 
 fun VersionCatalogBuilder.voice() {
     version("lavaplayer", "2.2.6")
-    version("koe", "3.0.0-pre3")
+    version("koe", "3.0.0-pre4")
 
     library("lavaplayer", "dev.arbjerg", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "dev.arbjerg", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,7 @@ fun VersionCatalogBuilder.spring() {
 
 fun VersionCatalogBuilder.voice() {
     version("lavaplayer", "2.2.6")
-    version("koe", "3.0.0-pre4")
+    version("koe", "3.0.0-pre5")
 
     library("lavaplayer", "dev.arbjerg", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "dev.arbjerg", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")
@@ -47,7 +47,7 @@ fun VersionCatalogBuilder.voice() {
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").versionRef("koe")
 
 
-	version("libdave", "4afcde442")
+	version("libdave", "0.1.0")
 	val libDavePlatforms = listOf("linux-x86-64", "linux-x86", "linux-aarch64", "linux-arm", "linux-musl-x86-64", "linux-musl-aarch64", "win-x86-64", "win-x86", "darwin")
 	libDavePlatforms.forEach {
         library("libdave-natives-$it", "moe.kyokobot.libdave", "natives-$it").versionRef("libdave")


### PR DESCRIPTION
## v4.2.1
* Updated koe to version [`3.0.0-pre5`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre5)
* Updated libdave to version [`0.1.0`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.0)