### PR TITLE
release v4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Each release usually includes various fixes and improvements.
 The most noteworthy of these, as well as any features and breaking changes, are listed here.
 
+# v4.2.2
+* Updated koe to version [`3.0.0-pre6`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre6)
+* Updated libdave to version [`0.1.3`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.3)
+
 ## v4.2.1
 * Updated koe to version [`3.0.0-pre5`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre5)
 * Updated libdave to version [`0.1.0`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.0)

--- a/docs/changelog/v4.md
+++ b/docs/changelog/v4.md
@@ -1,3 +1,7 @@
+# v4.2.2
+* Updated koe to version [`3.0.0-pre6`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre6)
+* Updated libdave to version [`0.1.3`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.3)
+
 ## v4.2.1
 * Updated koe to version [`3.0.0-pre5`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre5)
 * Updated libdave to version [`0.1.0`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.0)

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -4,54 +4,41 @@ description: A list of Lavalink client libraries.
 
 # Client Libraries
 
-| Client                                                              | Platform           | Compatible With                            | Additional Information             |
-|---------------------------------------------------------------------|--------------------|--------------------------------------------|------------------------------------|
-| [Lavalink-Client](https://github.com/lavalink-devs/Lavalink-Client) | Java/Kotlin/JVM    | JDA/Discord4J/**Any**                      | Uses reactor                       |
-| [Lavalink.kt](https://github.com/DRSchlaubi/Lavalink.kt)            | Kotlin             | Kord/JDA/**Any**                           | Kotlin Coroutines                  |
-| [DisGoLink](https://github.com/disgoorg/disgolink)                  | Go                 | **Any**                                    |                                    |
-| [lavalink.py](https://github.com/devoxin/lavalink.py)               | Python             | **Any**                                    |                                    |
-| [salada](https://github.com/ToddyTheNoobDud/Salad)                  | Python             | **Any**                                    |                                    |
-| [Mafic](https://github.com/ooliver1/mafic)                          | Python             | discord.py **V2**/nextcord/disnake/py-cord |                                    |
-| [Wavelink](https://github.com/PythonistaGuild/Wavelink)             | Python             | discord.py **V2**                          | `Unmaintained`                     |
-| [Pomice](https://github.com/cloudwithax/pomice)                     | Python             | discord.py **V2**                          |                                    |
-| [hikari-ongaku](https://github.com/MPlatypus/hikari-ongaku)         | Python             | Hikari                                     | `asyncio`-based                    |
-| [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)           | Python             | **Any**                                    | `asyncio`-based libraries 1.0.13a+ |
-| [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js            | **Any**                                    |                                    |
-| [Magmastream](https://github.com/Blackfort-Hosting/magmastream)     | Node.js            | **Any**                                    |                                    |
-| [Lavacord](https://github.com/lavacord/Lavacord)                    | Node.js/TypeScript | **Any**                                    |                                    |
-| [Shoukaku](https://github.com/Deivu/Shoukaku)                       | Node.js            | **Any**                                    |                                    |
-| [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client)    | Node.js            | discord.js/DiscordDeno/Eris/**Any**        | `async`                            |
-| [FastLink](https://github.com/PerformanC/FastLink)                  | Node.js            | **Any**                                    |                                    |
-| [Riffy](https://github.com/riffy-team/riffy)                        | Node.js            | **Any**                                    |                                    |
-| [lavaclient](https://npmjs.com/lavaclient)                          | Node.js            | **Any**                                    | v5+                                |
-| [TsumiLink](https://github.com/Fyphen1223/TsumiLink)                | Node.js            | **Any**                                    |                                    |
-| [Blue.ts](https://github.com/ftrapture/blue.ts)                     | Node.js            | Discord.js/Eris/OceanicJs                  |                                    |
-| [Rainlink](https://github.com/RainyXeon/Rainlink)                   | Node.js            | **Any**                                    |                                    |
-| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)       | .NET               | DisCatSharp                                | v10.4.2+                           |
-| [Lavalink4NET](https://github.com/angelobreuer/Lavalink4NET)        | .NET               | Discord.Net/DSharpPlus/Remora/NetCord      | v4+                                |
-| [Nomia](https://github.com/DHCPCD9/Nomia)                           | .NET               | DSharpPlus                                 |                                    |
-| [Coglink](https://github.com/PerformanC/Coglink)                    | C                  | Concord                                    |                                    |
-| [Anchorage](https://github.com/Deivu/Anchorage)                     | Rust               | **Any**                                    | `tokio`-based                      |
-| [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)             | Rust, Python       | **Any**                                    | `tokio`-based, `asyncio`-based     |
-| [lavalink](https://github.com/nyxx-discord/nyxx_lavalink)           | Dart               | nyxx/**Any**                               |                                    |
+| Client                                                              | Platform           | Compatible With                            | DAVE Support | Additional Information             |
+|---------------------------------------------------------------------|--------------------|--------------------------------------------|--------------|------------------------------------|
+| [Lavalink-Client](https://github.com/lavalink-devs/Lavalink-Client) | Java/Kotlin/JVM    | JDA/Discord4J/**Any**                      | ✅            | Uses reactor                       |
+| [Lavalink.kt](https://github.com/DRSchlaubi/Lavalink.kt)            | Kotlin             | Kord/JDA/**Any**                           | ✅            | Kotlin Coroutines                  |
+| [DisGoLink](https://github.com/disgoorg/disgolink)                  | Go                 | **Any**                                    | ✅            |                                    |
+| [lavalink.py](https://github.com/devoxin/lavalink.py)               | Python             | **Any**                                    | ✅            |                                    |
+| [Mafic](https://github.com/ooliver1/mafic)                          | Python             | discord.py **V2**/nextcord/disnake/py-cord | ✅            |
+| [Pomice](https://github.com/cloudwithax/pomice)                     | Python             | discord.py **V2**                          | ✅            |                                    |
+| [hikari-ongaku](https://github.com/MPlatypus/hikari-ongaku)         | Python             | Hikari                                     | ✅            | `asyncio`-based                    |
+| [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)           | Python             | **Any**                                    | ✅            | `asyncio`-based libraries 1.0.13a+ |
+| [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js            | **Any**                                    | ✅            |                                    |
+| [Shoukaku](https://github.com/Deivu/Shoukaku)                       | Node.js            | **Any**                                    | ✅            |                                    |
+| [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client)    | Node.js            | discord.js/DiscordDeno/Eris/**Any**        | ✅            | `async`                            |
+| [FastLink](https://github.com/PerformanC/FastLink)                  | Node.js            | **Any**                                    | ✅            |                                    |
+| [Riffy](https://github.com/riffy-team/riffy)                        | Node.js            | **Any**                                    | ✅            |                                    |
+| [lavaclient](https://github.com/lavaclient/lavaclient)              | Node.js            | **Any**                                    | ✅            | v5+                                |
+| [Rainlink](https://github.com/RainyXeon/Rainlink)                   | Node.js            | **Any**                                    | ✅            |                                    |
+| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)       | .NET               | DisCatSharp                                | ✅            | v10.4.2+                           |
+| [Lavalink4NET](https://github.com/angelobreuer/Lavalink4NET)        | .NET               | Discord.Net/DSharpPlus/Remora/NetCord      | ✅            | v4+                                |
+| [Coglink](https://github.com/PerformanC/Coglink)                    | C                  | Concord                                    | ✅            |                                    |
+| [Anchorage](https://github.com/Deivu/Anchorage)                     | Rust               | **Any**                                    | ✅            | `tokio`-based                      |
+| [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs)             | Rust, Python       | **Any**                                    | ✅            | `tokio`-based, `asyncio`-based     |
 
-<details markdown="1">
-<summary>v3.7 supporting Client Libraries</summary>
+<details markdown="1">¶
+<summary>Not DAVE supporting Client Libraries</summary>
 
-| Client                                                        | Platform | Compatible With                            | Additional Information             |
-|---------------------------------------------------------------|----------|--------------------------------------------|------------------------------------|
-| [Lavalink.kt](https://github.com/DRSchlaubi/lavalink.kt)      | Kotlin   | JDA/Kord/**Any**                           | Kotlin Coroutines                  |
-| [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)     | Python   | **Any\***                                  | `asyncio`-based libraries 1.0.12a> |
-| [Mafic](https://github.com/ooliver1/mafic)                    | Python   | discord.py **V2**/nextcord/disnake/py-cord |                                    |
-| [Wavelink](https://github.com/PythonistaGuild/Wavelink)       | Python   | discord.py **V2**                          | `Unmaintained`, Version >=2, <3    |
-| [Pomice](https://github.com/cloudwithax/pomice)               | Python   | discord.py **V2**                          |                                    |
-| [Lavacord](https://github.com/lavacord/lavacord)              | Node.js  | **Any**                                    | < v3                               |
-| [Poru](https://github.com/parasop/poru)                       | Node.js  | **Any**                                    |                                    |
-| [Shoukaku](https://github.com/Deivu/Shoukaku)                 | Node.js  | **Any**                                    |                                    |
-| [Cosmicord.js](https://github.com/SudhanPlayz/Cosmicord.js)   | Node.js  | **Any**                                    |                                    |
-| [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp) | .NET     | DisCatSharp                                | Only prior v10.4.1                 |
-| [Lavalink4NET](https://github.com/angelobreuer/Lavalink4NET)  | .NET     | Discord.Net/DSharpPlus                     | < v4                               |
-| [DisGoLink](https://github.com/disgoorg/disgolink)            | Go       | **Any**                                    |                                    |
+| Client                                                          | Platform           | Compatible With           | DAVE Support | Additional Information |
+|-----------------------------------------------------------------|--------------------|---------------------------|--------------|------------------------|
+| [salada](https://github.com/ToddyTheNoobDud/Salad)              | Python             | **Any**                   | ❌            | `Unmaintained`         |
+| [Magmastream](https://github.com/Blackfort-Hosting/magmastream) | Node.js            | **Any**                   | ❌            | `Unmaintained`         |
+| [Lavacord](https://github.com/lavacord/Lavacord)                | Node.js/TypeScript | **Any**                   | ❌            | `Unmaintained`         |
+| [TsumiLink](https://github.com/Fyphen1223/TsumiLink)            | Node.js            | **Any**                   | ❌            | `Unmaintained`         |
+| [Blue.ts](https://github.com/ftrapture/blue.ts)                 | Node.js            | Discord.js/Eris/OceanicJs | ❌            | `Unmaintained`         |
+| [Nomia](https://github.com/DHCPCD9/Nomia)                       | .NET               | DSharpPlus                | ❌            | `Unmaintained`         |
+| [lavalink](https://github.com/nyxx-discord/nyxx_lavalink)       | Dart               | nyxx/**Any**              | ❌            | `Unmaintained`         |
 
 </details>
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,7 @@ fun VersionCatalogBuilder.spring() {
 
 fun VersionCatalogBuilder.voice() {
     version("lavaplayer", "2.2.6")
-    version("koe", "3.0.0-pre5")
+    version("koe", "3.0.0-pre6")
 
     library("lavaplayer", "dev.arbjerg", "lavaplayer").versionRef("lavaplayer")
     library("lavaplayer-ip-rotator", "dev.arbjerg", "lavaplayer-ext-youtube-rotator").versionRef("lavaplayer")
@@ -47,7 +47,7 @@ fun VersionCatalogBuilder.voice() {
     library("koe-udpqueue", "moe.kyokobot.koe", "ext-udpqueue").versionRef("koe")
 
 
-	version("libdave", "0.1.0")
+	version("libdave", "0.1.3")
 	val libDavePlatforms = listOf("linux-x86-64", "linux-x86", "linux-aarch64", "linux-arm", "linux-musl-x86-64", "linux-musl-aarch64", "win-x86-64", "win-x86", "darwin")
 	libDavePlatforms.forEach {
         library("libdave-natives-$it", "moe.kyokobot.libdave", "natives-$it").versionRef("libdave")


### PR DESCRIPTION
# v4.2.2
* Updated koe to version [`3.0.0-pre6`](https://github.com/KyokoBot/koe/releases/tag/3.0.0-pre6)
* Updated libdave to version [`0.1.3`](https://github.com/KyokoBot/libdave-jvm/releases/tag/0.1.3)