### PR TITLE
Use ConcurrentHashMap for resumableSessions

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/SocketServer.kt
@@ -51,7 +51,7 @@ final class SocketServer(
 
     // sessionID <-> Session
     override val sessions = ConcurrentHashMap<String, SocketContext>()
-    override val resumableSessions = mutableMapOf<String, SocketContext>()
+    override val resumableSessions = ConcurrentHashMap<String, SocketContext>()
     private val koe = Koe.koe(koeOptions)
     private val statsCollector = StatsCollector(this)
     private val charPool = ('a'..'z') + ('0'..'9')


### PR DESCRIPTION
`resumableSessions` in `SocketServer` is currently backed by a plain `mutableMapOf()` (i.e. `LinkedHashMap`), but it's accessed from multiple threads:

- WebSocket handler threads call `remove`/`put` in `afterConnectionEstablished` and `afterConnectionClosed`
- The scheduled executor from `SocketContext.pause()` calls `onSessionResumeTimeout` which does `remove`
- `canResume` reads it from the handshake interceptor thread

This is a race condition that can silently corrupt the map's internal state or throw a `ConcurrentModificationException` at runtime. The `sessions` map right above it already uses `ConcurrentHashMap` for the same reason, so this just makes `resumableSessions` consistent.

One-line change, no new dependencies since `ConcurrentHashMap` is already imported.