### PR TITLE
docs: add relink to client libraries

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,6 +12,7 @@ description: A list of Lavalink client libraries.
 | [lavalink.py](https://github.com/devoxin/lavalink.py)               | Python          | **Any**                                    | ✅            |                                    |
 | [Mafic](https://github.com/ooliver1/mafic)                          | Python          | discord.py **V2**/nextcord/disnake/py-cord | ✅            |                                    |
 | [Pomice](https://github.com/cloudwithax/pomice)                     | Python          | discord.py **V2**                          | ✅            |                                    |
+| [ReWaveLink](https://github.com/rewavelink/relink)                  | Python          | discord.py **V2**                          | ✅            |                                    |
 | [hikari-ongaku](https://github.com/MPlatypus/hikari-ongaku)         | Python          | Hikari                                     | ✅            | `asyncio`-based                    |
 | [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)           | Python          | **Any**                                    | ✅            | `asyncio`-based libraries 1.0.13a+ |
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js         | **Any**                                    | ✅            |                                    |


### PR DESCRIPTION
On behalf of the @ReWaveLink dev. team, I'm submitting this PR to include **ReLink** in the official list of Lavalink client libraries.

**Re[Wave]Link** is a high-performance Lavalink wrapper for discord.py v2. While the project was initially conceived as a WaveLink Reborn, the development team (@vmphase, @DA-344 and @soheab) opted to do it from scratch to ensure a clean and maintainable library. Anyways, it is still remains faithful to the original MIT License.

- Repository: https://github.com/rewavelink/relink
- Documentation: https://relink.readthedocs.io/en/latest
- PyPi Release: https://pypi.org/project/rewavelink

We are committed to the long-term maintenance of ReLink and its continued alignment with Lavalink.