### PR TITLE
docs: update relink compatibility

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,7 +12,7 @@ description: A list of Lavalink client libraries.
 | [lavalink.py](https://github.com/devoxin/lavalink.py)               | Python          | **Any**                                    | ✅            |                                    |
 | [Mafic](https://github.com/ooliver1/mafic)                          | Python          | discord.py **V2**/nextcord/disnake/py-cord | ✅            |                                    |
 | [Pomice](https://github.com/cloudwithax/pomice)                     | Python          | discord.py **V2**                          | ✅            |                                    |
-| [ReWaveLink](https://github.com/rewavelink/relink)                  | Python          | discord.py **V2**                          | ✅            |                                    |
+| [ReWaveLink](https://github.com/rewavelink/relink)                  | Python          | discord.py **V2**/py-cord/disnake          | ✅            |                                    |
 | [hikari-ongaku](https://github.com/MPlatypus/hikari-ongaku)         | Python          | Hikari                                     | ✅            | `asyncio`-based                    |
 | [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)           | Python          | **Any**                                    | ✅            | `asyncio`-based libraries 1.0.13a+ |
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js         | **Any**                                    | ✅            |                                    |


### PR DESCRIPTION
PR to extend **Re[Wave]Link**'s compatibility to additional discord frameworks.
Starting from v1.1.0 it supports not only discord.py v2, but also py-cord and disnake.

- Repository: https://github.com/rewavelink/relink
- Documentation: https://relink.readthedocs.io/en/latest
- PyPi Release: https://pypi.org/project/rewavelink