### PR TITLE
docs: add SonoLink Client

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -13,7 +13,7 @@ description: A list of Lavalink client libraries.
 | [Mafic](https://github.com/ooliver1/mafic)                          | Python          | discord.py **V2**/nextcord/disnake/py-cord | ✅            |                                    |
 | [Pomice](https://github.com/cloudwithax/pomice)                     | Python          | discord.py **V2**                          | ✅            |                                    |
 | [Wavelink](https://github.com/PythonistaGuild/Wavelink)             | Python          | discord.py **V2**                          | ✅            |                                    |
-| [SonoLink](https://github.com/sonolink/sonolink)                    | Python          | discord.py **V2**/py-cord/disnake          | ✅            |                                    |
+| [SonoLink](https://github.com/sonolink/sonolink)                    | Python          | discord.py **V2**/py-cord/disnake/nextcord | ✅            |                                    |
 | [hikari-ongaku](https://github.com/MPlatypus/hikari-ongaku)         | Python          | Hikari                                     | ✅            | `asyncio`-based                    |
 | [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)           | Python          | **Any**                                    | ✅            | `asyncio`-based libraries 1.0.13a+ |
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js         | **Any**                                    | ✅            |                                    |

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,7 +12,7 @@ description: A list of Lavalink client libraries.
 | [lavalink.py](https://github.com/devoxin/lavalink.py)               | Python          | **Any**                                    | ✅            |                                    |
 | [Mafic](https://github.com/ooliver1/mafic)                          | Python          | discord.py **V2**/nextcord/disnake/py-cord | ✅            |                                    |
 | [Pomice](https://github.com/cloudwithax/pomice)                     | Python          | discord.py **V2**                          | ✅            |                                    |
-| [ReWaveLink](https://github.com/rewavelink/relink)                  | Python          | discord.py **V2**/py-cord/disnake          | ✅            |                                    |
+| [SonoLink](https://github.com/sonolink/sonolink)                    | Python          | discord.py **V2**/py-cord/disnake          | ✅            |                                    |
 | [hikari-ongaku](https://github.com/MPlatypus/hikari-ongaku)         | Python          | Hikari                                     | ✅            | `asyncio`-based                    |
 | [lavaplay.py](https://github.com/HazemMeqdad/lavaplay.py)           | Python          | **Any**                                    | ✅            | `asyncio`-based libraries 1.0.13a+ |
 | [Moonlink.js](https://github.com/1Lucas1apk/moonlink.js)            | Node.js         | **Any**                                    | ✅            |                                    |


### PR DESCRIPTION
ReWaveLink has recently rebranded due to some internal discussions and is now named **SonoLink**.

~~This PR will be flagged as a draft until the actual PyPi package migration has been fully done.~~

This would maybe also imply renaming [the dedicated channel](https://discord.com/channels/1082302532421943407/1490534419981668434 "Lavalink/#py_rewavelink") to "py_sonolink"?

- Repository: https://github.com/sonolink/sonolink
- Documentation: https://sonolink.readthedocs.io/en/latest
- PyPi Release: https://pypi.org/project/sonolink