### PR TITLE
docs: added Lunacord.js to clients

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -23,6 +23,7 @@ description: A list of Lavalink client libraries.
 | [Riffy](https://github.com/riffy-team/riffy)                        | Node.js         | **Any**                                    | ✅            |                                    |
 | [lavaclient](https://github.com/lavaclient/lavaclient)              | Node.js         | **Any**                                    | ✅            | v5+                                |
 | [Rainlink](https://github.com/RainyXeon/Rainlink)                   | Node.js         | **Any**                                    | ✅            |                                    |
+| [Lunacord.js](https://github.com/NotWrench/Lunacord.js)              | Node.js | discord.js/**Any**                      | ✅            | Lavalink v4, ESM, `MusicKit`       |
 | [DisCatSharp](https://github.com/Aiko-IT-Systems/DisCatSharp)       | .NET            | DisCatSharp                                | ✅            | v10.7.0+                           |
 | [Lavalink4NET](https://github.com/angelobreuer/Lavalink4NET)        | .NET            | Discord.Net/DSharpPlus/Remora/NetCord      | ✅            | v4+                                |
 | [Coglink](https://github.com/PerformanC/Coglink)                    | C               | Concord                                    | ✅            |                                    |


### PR DESCRIPTION
Added a new Node.js client library
Lunacord.js: a Lavalink v4 TypeScript client with a builder API, plugins, optional Redis persistence, lyrics providers, and a discord.js MusicKit adapter (plus an npm umbrella package with a small client preset).

Links:
[Github](https://github.com/NotWrench/Lunacord.js)
[Docs](https://lunacord-js-docs.vercel.app/)
[NPM - Core](https://www.npmjs.com/package/@lunacord/core)
[NPM - Umbrella package](https://www.npmjs.com/package/lunacord.js)

Me and one more developer previously owned Cosmicord.js but we dropped it and created a new one