### PR TITLE
fix: multiple typos and error handling improvements

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/info/InfoRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/info/InfoRestHandler.kt
@@ -22,7 +22,7 @@ class InfoRestHandler(
     filterExtensions: List<AudioFilterExtension>
 ) {
 
-    private val enabledFilers = (listOf(
+    private val enabledFilters = (listOf(
         "volume",
         "equalizer",
         "karaoke",
@@ -44,7 +44,7 @@ class InfoRestHandler(
         System.getProperty("java.version"),
         PlayerLibrary.VERSION,
         audioPlayerManager.sourceManagers.map { it.sourceName },
-        enabledFilers,
+        enabledFilters,
         Plugins(pluginManager.pluginManifests.map {
             Plugin(it.name, it.version)
         })

--- a/LavalinkServer/src/main/java/lavalink/server/io/EventEmitter.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/io/EventEmitter.kt
@@ -22,7 +22,7 @@ class EventEmitter(private val context: SocketContext, private val listeners: Co
         listeners.forEach {
             try {
                 func(it)
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 log.error("Error handling event", e)
             }
         }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here is a list of known working hardware:
 [^1]: Windows on ARM is not natively supported, but seems to work fine with x86-64 JVMs & emulation.
 
 > [!NOTE]
-> The minium supported version for glibc in DAVE is 2.35 (Ubuntu 22.04).
+> The minimum supported version for glibc in DAVE is 2.35 (Ubuntu 22.04).
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
This PR fixes multiple minor issues:

1. **Documentation typo**: Fixed "minium" → "minimum" in README.md
2. **Variable typo**: Fixed "enabledFilers" → "enabledFilters" in InfoRestHandler.kt
3. **Error handling**: Changed catch from [Exception](cci:2://file:///c:/Users/ankit/OneDrive/Desktop/lavalinkfork/Lavalink/protocol/src/commonMain/kotlin/dev/arbjerg/lavalink/protocol/v4/loadResult.kt:149:0-187:1) to `Throwable` in EventEmitter to handle all plugin errors (including Errors like OutOfMemoryError, StackOverflowError)

## Changes
- README.md: Fixed glibc version note typo
- InfoRestHandler.kt: Fixed variable name typo
- EventEmitter.kt: Improved error handling to prevent plugin crashes from propagating