### PR TITLE
docs(rest): update empty load result data type to null

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -104,10 +104,10 @@ Response:
 
 #### Track Loading Result
 
-| Field    | Type                                | Description            |       
-|----------|-------------------------------------|------------------------|
-| loadType | [LoadResultType](#load-result-type) | The type of the result | 
-| data     | [LoadResultData](#load-result-data) | The data of the result |
+| Field    | Type                                 | Description            |       
+|----------|--------------------------------------|------------------------|
+| loadType | [LoadResultType](#load-result-type)  | The type of the result | 
+| data     | ?[LoadResultData](#load-result-data) | The data of the result |
 
 #### Load Result Type
 

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -192,7 +192,7 @@ Array of [Track](#track) objects from the search result.
 
 ##### Empty Result Data
 
-Empty object.
+`null`.
 
 <details markdown="1">
 <summary>Example Payload</summary>
@@ -200,7 +200,7 @@ Empty object.
 ```yaml
 {
   "loadType": "empty",
-  "data": { }
+  "data": null
 }
 ```
 


### PR DESCRIPTION
Empty object (`{ }`) => `null`, as returned from the Lavalink itself.