### PR TITLE
Replace _JAVA_OPTIONS with JAVA_TOOL_OPTIONS

### DIFF
--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
     environment:
       # set Java options here (6GB heap size)
-      - _JAVA_OPTIONS=-Xmx6G
+      - JAVA_TOOL_OPTIONS=-Xmx6G
       # set lavalink server port
       # - SERVER_PORT=2333
       # set password for lavalink


### PR DESCRIPTION
`_JAVA_OPTIONS` was an implementation detail of hotspot, it has been replaced by `JAVA_TOOL_OPTIONS` in Java 5

Reference: https://bugs.openjdk.org/browse/JDK-4971166