### PR TITLE
fix: restore null endTime handling in player update

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt
@@ -171,9 +171,9 @@ class PlayerRestHandler(
                 }
             }
 
-        playerUpdate.endTime.takeIfPresent { encodedTrack is Omissible.Omitted && identifier is Omissible.Omitted }
-            ?.let { endTime ->
-                val marker = TrackMarker(endTime, TrackEndMarkerHandler(player))
+        playerUpdate.endTime.takeIf { it.isPresent() && encodedTrack is Omissible.Omitted && identifier is Omissible.Omitted }
+            ?.let {
+                val marker = (it as Omissible.Present).value?.let { endTime -> TrackMarker(endTime, TrackEndMarkerHandler(player)) }
                 player.track?.setMarker(marker)
             }
 


### PR DESCRIPTION
regressed in 2bdf608a, which dropped the it.value?.let {} null check ccb2ba9e introduced and replaced it with takeIfPresent {}, since takeIf on a null receiver always returns null regardless of the predicate's result, so an explicit endTime: null on PATCH /v4/sessions/{sessionId}/players/{guildId} never reaches setMarker(null)