### PR TITLE
Fix #1215: Configure java to use system default ip stack

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/Launcher.kt
@@ -115,6 +115,10 @@ object Launcher {
 
     @JvmStatic
     fun main(args: Array<String>) {
+        if (System.getProperty("java.net.preferIPv6Addresses") == null) {
+            System.setProperty("java.net.preferIPv6Addresses", "system")
+        }
+
         if (args.isNotEmpty() &&
             (args[0].equals("-v", ignoreCase = true) || args[0].equals("--version", ignoreCase = true))
         ) {


### PR DESCRIPTION
> Task :Lavalink-Server:test
lavalink.server.config.RequestAuthorizationFilterTest

  Test authenticatedRequest_Success() PASSED (1s)
  Test wrongAuthenticatedRequest_Fail() PASSED
  Test unauthenticatedRequest_Fail() PASSED

SUCCESS: Executed 3 tests in 8.8s
BUILD SUCCESSFUL in 29s
